### PR TITLE
remove any instance Oraculi from the github-action workflow

### DIFF
--- a/.github/workflows/hello-to-new-contributors.yml
+++ b/.github/workflows/hello-to-new-contributors.yml
@@ -16,5 +16,5 @@ jobs:
       - uses: actions/first-interaction@v1
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
-          issue-message: "Hey, thank you for opening your first Issue! 🙂 While an Oraculi team member takes a look at your issue we would like to invite you to join our official Discord server, where you can interact directly with other contributors and Oraculi team members. Link here: https://discord.oraculi.io"
-          pr-message: "Hey, thank you for opening your Pull Request ! 🙂 While an Oraculi team member takes a look at your PR we would like to invite you to join our official Discord server, where you can interact directly with other contributors and Oraculi team members. Link here: https://discord.oraculi.io"
+          issue-message: "Hey, thank you for opening your first Issue! 🙂 While a Tailwarden team member takes a look at your issue we would like to invite you to join our official Discord server, where you can interact directly with other contributors and Tailwarden team members. Link here: https://discord.tailwarden.com"
+          pr-message: "Hey, thank you for opening your Pull Request ! 🙂 While a Tailwarden team member takes a look at your PR we would like to invite you to join our official Discord server, where you can interact directly with other contributors and Tailwarden team members. Link here: https://discord.tailwarden.com"


### PR DESCRIPTION
We still had some legacy Oraculi links and intances that had to be changed to Tailwarden.
