### PR TITLE
feat: added cost filter to filters set

### DIFF
--- a/handlers/resources_handler.go
+++ b/handlers/resources_handler.go
@@ -191,6 +191,40 @@ func (handler *ApiHandler) FilterResourcesHandler(w http.ResponseWriter, r *http
 				respondWithError(w, http.StatusBadRequest, "Operation is invalid or not supported")
 				return
 			}
+		} else if filter.Field == "cost" {
+			switch filter.Operator {
+			case "EQUAL":
+				cost, err := strconv.ParseFloat(filter.Values[0], 64)
+				if err != nil {
+					respondWithError(w, http.StatusBadRequest, "The value should be a number")
+				}
+				whereQueries = append(whereQueries, fmt.Sprintf("(cost = %f)", cost))
+			case "BETWEEN":
+				min, err := strconv.ParseFloat(filter.Values[0], 64)
+				if err != nil {
+					respondWithError(w, http.StatusBadRequest, "The value should be a number")
+				}
+				max, err := strconv.ParseFloat(filter.Values[1], 64)
+				if err != nil {
+					respondWithError(w, http.StatusBadRequest, "The value should be a number")
+				}
+				whereQueries = append(whereQueries, fmt.Sprintf("(cost >= %f AND cost <= %f)", min, max))
+			case "GREATER_THAN":
+				cost, err := strconv.ParseFloat(filter.Values[0], 64)
+				if err != nil {
+					respondWithError(w, http.StatusBadRequest, "The value should be a number")
+				}
+				whereQueries = append(whereQueries, fmt.Sprintf("(cost > %f)", cost))
+			case "LESS_THAN":
+				cost, err := strconv.ParseFloat(filter.Values[0], 64)
+				if err != nil {
+					respondWithError(w, http.StatusBadRequest, "The value should be a number")
+				}
+				whereQueries = append(whereQueries, fmt.Sprintf("(cost < %f)", cost))
+			default:
+				respondWithError(w, http.StatusBadRequest, "Operation is invalid or not supported")
+				return
+			}
 		} else {
 			respondWithError(w, http.StatusBadRequest, "Field is invalid or not supported")
 			return

--- a/handlers/stats_handler.go
+++ b/handlers/stats_handler.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/http"
+	"strconv"
 	"strings"
 
 	. "github.com/tailwarden/komiser/models"
@@ -144,6 +145,40 @@ func (handler *ApiHandler) FilterStatsHandler(w http.ResponseWriter, r *http.Req
 				} else {
 					whereQueries = append(whereQueries, "jsonb_array_length(tags) != 0")
 				}
+			default:
+				respondWithError(w, http.StatusBadRequest, "Operation is invalid or not supported")
+				return
+			}
+		} else if filter.Field == "cost" {
+			switch filter.Operator {
+			case "EQUAL":
+				cost, err := strconv.ParseFloat(filter.Values[0], 64)
+				if err != nil {
+					respondWithError(w, http.StatusBadRequest, "The value should be a number")
+				}
+				whereQueries = append(whereQueries, fmt.Sprintf("(cost = %f)", cost))
+			case "BETWEEN":
+				min, err := strconv.ParseFloat(filter.Values[0], 64)
+				if err != nil {
+					respondWithError(w, http.StatusBadRequest, "The value should be a number")
+				}
+				max, err := strconv.ParseFloat(filter.Values[1], 64)
+				if err != nil {
+					respondWithError(w, http.StatusBadRequest, "The value should be a number")
+				}
+				whereQueries = append(whereQueries, fmt.Sprintf("(cost >= %f AND cost <= %f)", min, max))
+			case "GREATER_THAN":
+				cost, err := strconv.ParseFloat(filter.Values[0], 64)
+				if err != nil {
+					respondWithError(w, http.StatusBadRequest, "The value should be a number")
+				}
+				whereQueries = append(whereQueries, fmt.Sprintf("(cost > %f)", cost))
+			case "LESS_THAN":
+				cost, err := strconv.ParseFloat(filter.Values[0], 64)
+				if err != nil {
+					respondWithError(w, http.StatusBadRequest, "The value should be a number")
+				}
+				whereQueries = append(whereQueries, fmt.Sprintf("(cost < %f)", cost))
 			default:
 				respondWithError(w, http.StatusBadRequest, "Operation is invalid or not supported")
 				return


### PR DESCRIPTION
### Description


The actual endpoints now support the cost field. The supported operators are:

```
BETWEEN
EQUAL
GREATER_THAN
LESS_THAN
```

### Related Issue

https://github.com/tailwarden/komiser/issues/274
