### PR TITLE
Filter resources by cost + minor improvements

### DIFF
--- a/dashboard/.eslintrc.json
+++ b/dashboard/.eslintrc.json
@@ -3,7 +3,7 @@
   "plugins": ["prettier"],
   "rules": {
     "react-hooks/exhaustive-deps": "off",
-    "prettier/prettier": ["warn", {"endOfLine": "auto"}],
+    "prettier/prettier": ["warn", { "endOfLine": "auto" }],
     "import/extensions": [
       "error",
       "ignorePackages",

--- a/dashboard/components/input/Input.tsx
+++ b/dashboard/components/input/Input.tsx
@@ -13,6 +13,7 @@ export type InputProps = {
   autofocus?: boolean;
   min?: number;
   positiveNumberOnly?: boolean;
+  restrictURLParams?: boolean;
   action: (newData: any, id?: number) => void;
 };
 
@@ -27,6 +28,7 @@ function Input({
   autofocus,
   min,
   positiveNumberOnly,
+  restrictURLParams,
   action
 }: InputProps) {
   const [isValid, setIsValid] = useState<boolean | undefined>(undefined);
@@ -51,9 +53,18 @@ function Input({
   }
 
   function handleKeyDown(e: KeyboardEvent) {
-    const invalidChars = ['-', '+', 'e'];
-    if (invalidChars.includes(e.key)) {
-      e.preventDefault();
+    if (positiveNumberOnly) {
+      const invalidChars = ['-', '+', 'e'];
+      if (invalidChars.includes(e.key)) {
+        e.preventDefault();
+      }
+    }
+
+    if (restrictURLParams) {
+      const invalidChars = ['#', '"', '=', '&', '+', '*'];
+      if (invalidChars.includes(e.key)) {
+        e.preventDefault();
+      }
     }
   }
 
@@ -76,11 +87,7 @@ function Input({
               action({ [name]: e.target.value });
             }
           }}
-          onKeyDown={e => {
-            if (positiveNumberOnly) {
-              handleKeyDown(e);
-            }
-          }}
+          onKeyDown={e => handleKeyDown(e)}
           value={value}
           ref={inputRef}
           min={min}

--- a/dashboard/components/input/Input.tsx
+++ b/dashboard/components/input/Input.tsx
@@ -13,7 +13,6 @@ export type InputProps = {
   autofocus?: boolean;
   min?: number;
   positiveNumberOnly?: boolean;
-  restrictURLParams?: boolean;
   action: (newData: any, id?: number) => void;
 };
 
@@ -28,7 +27,6 @@ function Input({
   autofocus,
   min,
   positiveNumberOnly,
-  restrictURLParams,
   action
 }: InputProps) {
   const [isValid, setIsValid] = useState<boolean | undefined>(undefined);
@@ -55,13 +53,6 @@ function Input({
   function handleKeyDown(e: KeyboardEvent) {
     if (positiveNumberOnly) {
       const invalidChars = ['-', '+', 'e'];
-      if (invalidChars.includes(e.key)) {
-        e.preventDefault();
-      }
-    }
-
-    if (restrictURLParams) {
-      const invalidChars = ['#', '"', '=', '&', '+', '*'];
       if (invalidChars.includes(e.key)) {
         e.preventDefault();
       }

--- a/dashboard/components/input/Input.tsx
+++ b/dashboard/components/input/Input.tsx
@@ -1,4 +1,4 @@
-import { ChangeEvent, useEffect, useRef, useState } from 'react';
+import { ChangeEvent, KeyboardEvent, useEffect, useRef, useState } from 'react';
 
 export type InputEvent = ChangeEvent<HTMLInputElement>;
 
@@ -11,6 +11,8 @@ export type InputProps = {
   error: string;
   value?: string | number | string[];
   autofocus?: boolean;
+  min?: number;
+  positiveNumberOnly?: boolean;
   action: (newData: any, id?: number) => void;
 };
 
@@ -23,6 +25,8 @@ function Input({
   error,
   value,
   autofocus,
+  min,
+  positiveNumberOnly,
   action
 }: InputProps) {
   const [isValid, setIsValid] = useState<boolean | undefined>(undefined);
@@ -46,6 +50,13 @@ function Input({
     setIsValid(undefined);
   }
 
+  function handleKeyDown(e: KeyboardEvent) {
+    const invalidChars = ['-', '+', 'e'];
+    if (invalidChars.includes(e.key)) {
+      e.preventDefault();
+    }
+  }
+
   return (
     <div>
       <div className="relative">
@@ -65,8 +76,14 @@ function Input({
               action({ [name]: e.target.value });
             }
           }}
+          onKeyDown={e => {
+            if (positiveNumberOnly) {
+              handleKeyDown(e);
+            }
+          }}
           value={value}
           ref={inputRef}
+          min={min}
           autoComplete="off"
           data-lpignore="true"
           data-form-type="other"

--- a/dashboard/components/inventory/components/InventoryViewsTabs.tsx
+++ b/dashboard/components/inventory/components/InventoryViewsTabs.tsx
@@ -13,7 +13,9 @@ function InventoryViewsTabs({ views, router }: InventoryViewsTabsProps) {
         <ul className="flex flex-wrap justify-between sm:justify-start -mb-[2px]">
           <li>
             <a
-              onClick={() => router.push('/')}
+              onClick={() => {
+                if (router.asPath !== '/') router.push('/');
+              }}
               className={`select-none inline-block py-4 px-2 sm:p-4 rounded-t-lg border-b-2 border-transparent hover:text-komiser-700 cursor-pointer 
                        ${
                          !router.query.view &&
@@ -28,7 +30,14 @@ function InventoryViewsTabs({ views, router }: InventoryViewsTabsProps) {
             views.map((view, idx) => (
               <li key={idx}>
                 <a
-                  onClick={() => router.push(`/?view=${view.name}`)}
+                  onClick={() => {
+                    if (
+                      router.asPath.replaceAll('%20', ' ') !==
+                      `/?view=${view.name}`
+                    ) {
+                      router.push(`/?view=${view.name}`);
+                    }
+                  }}
                   className={`select-none inline-block py-4 px-2 sm:p-4 rounded-t-lg border-b-2 border-transparent hover:text-komiser-700 cursor-pointer whitespace-nowrap
                        ${
                          router.asPath.replaceAll('%20', ' ') ===

--- a/dashboard/components/inventory/components/InventoryViewsTabs.tsx
+++ b/dashboard/components/inventory/components/InventoryViewsTabs.tsx
@@ -31,17 +31,13 @@ function InventoryViewsTabs({ views, router }: InventoryViewsTabsProps) {
               <li key={idx}>
                 <a
                   onClick={() => {
-                    if (
-                      router.asPath.replaceAll('%20', ' ') !==
-                      `/?view=${view.name}`
-                    ) {
-                      router.push(`/?view=${view.name}`);
+                    if (router.query.view !== view.id.toString()) {
+                      router.push(`/?view=${view.id}`);
                     }
                   }}
                   className={`select-none inline-block py-4 px-2 sm:p-4 rounded-t-lg border-b-2 border-transparent hover:text-komiser-700 cursor-pointer whitespace-nowrap
                        ${
-                         router.asPath.replaceAll('%20', ' ') ===
-                           `/?view=${view.name}` &&
+                         router.query.view === view.id.toString() &&
                          `text-komiser-600 border-komiser-600 hover:text-komiser-600`
                        }`}
                 >

--- a/dashboard/components/inventory/components/filter/InventoryFilter.tsx
+++ b/dashboard/components/inventory/components/filter/InventoryFilter.tsx
@@ -32,6 +32,7 @@ function InventoryFilter({
     handleValueInput,
     costBetween,
     handleCostBetween,
+    inlineError,
     data,
     resetData,
     cleanValues,
@@ -112,6 +113,11 @@ function InventoryFilter({
                       handleCostBetween={handleCostBetween}
                     />
                   </div>
+                  {inlineError.hasError && (
+                    <p className="text-error-600 text-xs pb-4 font-medium">
+                      {inlineError.message}
+                    </p>
+                  )}
                   <div className="flex justify-end border-t -mx-4 -mb-4 px-4 py-4">
                     <Button
                       type="submit"

--- a/dashboard/components/inventory/components/filter/InventoryFilter.tsx
+++ b/dashboard/components/inventory/components/filter/InventoryFilter.tsx
@@ -30,6 +30,8 @@ function InventoryFilter({
     handleTagKey,
     handleValueCheck,
     handleValueInput,
+    costBetween,
+    handleCostBetween,
     data,
     resetData,
     cleanValues,
@@ -106,6 +108,8 @@ function InventoryFilter({
                       handleValueInput={handleValueInput}
                       cleanValues={cleanValues}
                       setToast={setToast}
+                      costBetween={costBetween}
+                      handleCostBetween={handleCostBetween}
                     />
                   </div>
                   <div className="flex justify-end border-t -mx-4 -mb-4 px-4 py-4">

--- a/dashboard/components/inventory/components/filter/InventoryFilterFieldOptions.tsx
+++ b/dashboard/components/inventory/components/filter/InventoryFilterFieldOptions.tsx
@@ -153,6 +153,34 @@ const inventoryFilterFieldOptions: InventoryFilterFieldOptionsProps[] = [
     )
   },
   {
+    label: 'Cost',
+    value: 'cost',
+    icon: (
+      <svg
+        xmlns="http://www.w3.org/2000/svg"
+        width="24"
+        height="24"
+        fill="none"
+        viewBox="0 0 24 24"
+      >
+        <path
+          stroke="currentColor"
+          strokeLinecap="round"
+          strokeLinejoin="round"
+          strokeWidth="2"
+          d="M8.672 14.33c0 1.29.99 2.33 2.22 2.33h2.51c1.07 0 1.94-.91 1.94-2.03 0-1.22-.53-1.65-1.32-1.93l-4.03-1.4c-.79-.28-1.32-.71-1.32-1.93 0-1.12.87-2.03 1.94-2.03h2.51c1.23 0 2.22 1.04 2.22 2.33M12 6v12"
+        ></path>
+        <path
+          stroke="currentColor"
+          strokeLinecap="round"
+          strokeLinejoin="round"
+          strokeWidth="2"
+          d="M12 22c5.523 0 10-4.477 10-10S17.523 2 12 2 2 6.477 2 12s4.477 10 10 10z"
+        ></path>
+      </svg>
+    )
+  },
+  {
     label: 'All tags',
     value: 'tags',
     icon: (

--- a/dashboard/components/inventory/components/filter/InventoryFilterOperator.tsx
+++ b/dashboard/components/inventory/components/filter/InventoryFilterOperator.tsx
@@ -29,6 +29,26 @@ const inventoryFilterOperatorAllTagsOptions: InventoryFilterOperatorOptionsProps
     { label: 'which are not empty', value: 'IS_NOT_EMPTY' }
   ];
 
+const inventoryFilterOperatorCostOptions: InventoryFilterOperatorOptionsProps[] =
+  [
+    {
+      label: 'is equal to',
+      value: 'EQUAL'
+    },
+    {
+      label: 'is between',
+      value: 'BETWEEN'
+    },
+    {
+      label: 'is greater than',
+      value: 'GREATER_THAN'
+    },
+    {
+      label: 'is less than',
+      value: 'LESS_THAN'
+    }
+  ];
+
 function InventoryFilterOperator({
   data,
   handleOperator,
@@ -52,8 +72,9 @@ function InventoryFilterOperator({
         </div>
       )}
 
-      {/* Operators list */}
+      {/* Operators list which are not tags or cost */}
       {data.field !== 'tags' &&
+        data.field !== 'cost' &&
         inventoryFilterOperatorOptions.map((option, idx) => (
           <Button
             key={idx}
@@ -68,8 +89,26 @@ function InventoryFilterOperator({
             {option.label}
           </Button>
         ))}
+
+      {/* Operators list for tags */}
       {data.field === 'tags' &&
         inventoryFilterOperatorAllTagsOptions.map((option, idx) => (
+          <Button
+            key={idx}
+            size="sm"
+            style="ghost"
+            align="left"
+            gap="md"
+            transition={false}
+            onClick={() => handleOperator(option.value)}
+          >
+            {option.label}
+          </Button>
+        ))}
+
+      {/* Operators list for cost */}
+      {data.field === 'cost' &&
+        inventoryFilterOperatorCostOptions.map((option, idx) => (
           <Button
             key={idx}
             size="sm"

--- a/dashboard/components/inventory/components/filter/InventoryFilterSummary.tsx
+++ b/dashboard/components/inventory/components/filter/InventoryFilterSummary.tsx
@@ -109,7 +109,9 @@ function InventoryFilterSummary({
                 {value}
               </span>
               {data.values.length > 1 && idx < data.values.length - 1 && (
-                <span className="ml-1 font-medium text-black-900">or</span>
+                <span className="ml-1 font-medium text-black-900">
+                  {data.field === 'cost' ? 'and' : 'or'}
+                </span>
               )}
             </p>
           ))}

--- a/dashboard/components/inventory/components/filter/InventoryFilterSummary.tsx
+++ b/dashboard/components/inventory/components/filter/InventoryFilterSummary.tsx
@@ -110,7 +110,9 @@ function InventoryFilterSummary({
               </span>
               {data.values.length > 1 && idx < data.values.length - 1 && (
                 <span className="ml-1 font-medium text-black-900">
-                  {data.field === 'cost' ? 'and' : 'or'}
+                  {data.field === 'cost' && data.operator === 'BETWEEN'
+                    ? 'and'
+                    : 'or'}
                 </span>
               )}
             </p>

--- a/dashboard/components/inventory/components/filter/InventoryFilterSummary.tsx
+++ b/dashboard/components/inventory/components/filter/InventoryFilterSummary.tsx
@@ -104,7 +104,10 @@ function InventoryFilterSummary({
           data.values.map((value, idx) => (
             <p key={idx}>
               {idx === 0 && <span className="mr-1">:</span>}
-              <span>{value}</span>
+              <span>
+                {data.field === 'cost' && '$'}
+                {value}
+              </span>
               {data.values.length > 1 && idx < data.values.length - 1 && (
                 <span className="ml-1 font-medium text-black-900">or</span>
               )}

--- a/dashboard/components/inventory/components/filter/InventoryFilterSummary.tsx
+++ b/dashboard/components/inventory/components/filter/InventoryFilterSummary.tsx
@@ -38,6 +38,10 @@ function InventoryFilterSummary({
       return 'is not empty';
     if (param === 'IS_NOT_EMPTY' && data.field === 'tags')
       return 'which are not empty';
+    if (param === 'EQUAL') return 'is equal to';
+    if (param === 'BETWEEN') return 'is between';
+    if (param === 'GREATER_THAN') return 'is greater than';
+    if (param === 'LESS_THAN') return 'is less than';
     return param;
   }
 

--- a/dashboard/components/inventory/components/filter/InventoryFilterValue.tsx
+++ b/dashboard/components/inventory/components/filter/InventoryFilterValue.tsx
@@ -125,6 +125,7 @@ function InventoryFilterValue({
 
       {/* Display input for resource name and tag values */}
       {!options &&
+        data.field !== 'cost' &&
         data.operator !== 'IS_EMPTY' &&
         data.operator !== 'IS_NOT_EMPTY' && (
           <div className="pl-1 pt-2 pr-4 pb-2">
@@ -140,6 +141,24 @@ function InventoryFilterValue({
             />
           </div>
         )}
+
+      {/* Display input for cost */}
+      {!options && data.field === 'cost' && (
+        <div className="pl-1 pt-2 pr-4 pb-2">
+          <Input
+            type="number"
+            name="values"
+            label="Value"
+            value={data.values}
+            regex={regex.required}
+            error="Value must be higher than 0."
+            action={handleValueInput}
+            autofocus={true}
+            min={0}
+            positiveNumberOnly={true}
+          />
+        </div>
+      )}
     </div>
   );
 }

--- a/dashboard/components/inventory/components/filter/InventoryFilterValue.tsx
+++ b/dashboard/components/inventory/components/filter/InventoryFilterValue.tsx
@@ -5,6 +5,7 @@ import Checkbox from '../../../checkbox/Checkbox';
 import Input from '../../../input/Input';
 import { ToastProps } from '../../../toast/hooks/useToast';
 import { InventoryFilterDataProps } from '../../hooks/useInventory';
+import { CostBetween } from './hooks/useFilterWizard';
 
 type InventoryFilterValueProps = {
   data: InventoryFilterDataProps;
@@ -15,6 +16,8 @@ type InventoryFilterValueProps = {
   handleValueInput: (newValue: { values: string }) => void;
   cleanValues: () => void;
   setToast: (toast: ToastProps | undefined) => void;
+  costBetween: CostBetween;
+  handleCostBetween: (newValue: Partial<CostBetween>) => void;
 };
 
 type Options = string[];
@@ -24,7 +27,9 @@ function InventoryFilterValue({
   handleValueCheck,
   handleValueInput,
   cleanValues,
-  setToast
+  setToast,
+  costBetween,
+  handleCostBetween
 }: InventoryFilterValueProps) {
   const [options, setOptions] = useState<Options | undefined>();
 
@@ -142,8 +147,8 @@ function InventoryFilterValue({
           </div>
         )}
 
-      {/* Display input for cost */}
-      {!options && data.field === 'cost' && (
+      {/* Display input for cost when is equal, greater or less than */}
+      {!options && data.field === 'cost' && data.operator !== 'BETWEEN' && (
         <div className="pl-1 pt-2 pr-4 pb-2">
           <Input
             type="number"
@@ -157,6 +162,37 @@ function InventoryFilterValue({
             min={0}
             positiveNumberOnly={true}
           />
+        </div>
+      )}
+
+      {/* Display input for cost when is between */}
+      {!options && data.field === 'cost' && data.operator === 'BETWEEN' && (
+        <div className="pl-1 pt-2 pr-4 pb-2">
+          <div className="grid grid-cols-2 gap-4">
+            <Input
+              type="number"
+              name="min"
+              label="Min value"
+              value={costBetween.min}
+              regex={regex.required}
+              error="Value must be higher than 0."
+              action={handleCostBetween}
+              autofocus={true}
+              min={0}
+              positiveNumberOnly={true}
+            />
+            <Input
+              type="number"
+              name="max"
+              label="Max value"
+              value={costBetween.max}
+              regex={regex.required}
+              error="Value must be higher than 0."
+              action={handleCostBetween}
+              min={0}
+              positiveNumberOnly={true}
+            />
+          </div>
         </div>
       )}
     </div>

--- a/dashboard/components/inventory/components/filter/hooks/useFilterWizard.tsx
+++ b/dashboard/components/inventory/components/filter/hooks/useFilterWizard.tsx
@@ -1,5 +1,5 @@
 import { NextRouter } from 'next/router';
-import { ChangeEvent, useState } from 'react';
+import { ChangeEvent, useEffect, useState } from 'react';
 import { InventoryFilterDataProps } from '../../../hooks/useInventory';
 
 const INITIAL_DATA = {
@@ -9,18 +9,38 @@ const INITIAL_DATA = {
   values: []
 };
 
+const INITIAL_COST_BETWEEN = {
+  min: '',
+  max: ''
+};
+
 type InventoryFilterProps = {
   router: NextRouter;
   setSkippedSearch: (number: number) => void;
+};
+
+export type CostBetween = {
+  min: string;
+  max: string;
 };
 
 function useFilterWizard({ router, setSkippedSearch }: InventoryFilterProps) {
   const [step, setStep] = useState(0);
   const [isOpen, setIsOpen] = useState(false);
   const [data, setData] = useState<InventoryFilterDataProps>(INITIAL_DATA);
+  const [costBetween, setCostBetween] =
+    useState<CostBetween>(INITIAL_COST_BETWEEN);
+
+  useEffect(() => {
+    setData(prev => ({
+      ...prev,
+      values: [costBetween.min, costBetween.max]
+    }));
+  }, [costBetween]);
 
   function resetData() {
     setStep(0);
+    setCostBetween(INITIAL_COST_BETWEEN);
     setData({ ...INITIAL_DATA, values: [] });
   }
 
@@ -75,6 +95,10 @@ function useFilterWizard({ router, setSkippedSearch }: InventoryFilterProps) {
     setData(prev => ({ ...prev, values: [newValue.values] }));
   }
 
+  function handleCostBetween(newValue: Partial<CostBetween>) {
+    setCostBetween(prev => ({ ...prev, ...newValue }));
+  }
+
   function filter() {
     if (router.asPath === '/') {
       router.push(
@@ -109,11 +133,12 @@ function useFilterWizard({ router, setSkippedSearch }: InventoryFilterProps) {
     handleTagKey,
     handleValueCheck,
     handleValueInput,
+    costBetween,
+    handleCostBetween,
     data,
     resetData,
     cleanValues,
-    filter,
-    router
+    filter
   };
 }
 

--- a/dashboard/components/inventory/components/view/InventoryView.tsx
+++ b/dashboard/components/inventory/components/view/InventoryView.tsx
@@ -78,9 +78,7 @@ function InventoryView({
       {/* Sidepanel */}
       <Sidepanel isOpen={isOpen} closeModal={closeModal}>
         <SidepanelHeader
-          title={
-            router.query.view ? router.query.view.toString() : 'Save as a view'
-          }
+          title={router.query.view ? view.name : 'Save as a view'}
           subtitle={`${inventoryStats?.resources} ${
             inventoryStats?.resources === 1 ? 'resource' : 'resources'
           } ${
@@ -110,7 +108,6 @@ function InventoryView({
               value={view.name}
               action={handleChange}
               autofocus={true}
-              restrictURLParams={true}
             />
 
             <div className="ml-auto">

--- a/dashboard/components/inventory/components/view/InventoryView.tsx
+++ b/dashboard/components/inventory/components/view/InventoryView.tsx
@@ -110,6 +110,7 @@ function InventoryView({
               value={view.name}
               action={handleChange}
               autofocus={true}
+              restrictURLParams={true}
             />
 
             <div className="ml-auto">

--- a/dashboard/components/inventory/components/view/hooks/useViews.tsx
+++ b/dashboard/components/inventory/components/view/hooks/useViews.tsx
@@ -15,6 +15,7 @@ type useViewsProps = {
 };
 
 const INITIAL_VIEW: ViewProps = {
+  id: 0,
   name: '',
   filters: [],
   exclude: []
@@ -34,7 +35,7 @@ function useViews({ setToast, views, router, getViews }: useViewsProps) {
 
   function findView(currentViews: ViewProps[]) {
     return currentViews.find(
-      currentView => currentView.name === router.query.view
+      currentView => currentView.id.toString() === router.query.view
     );
   }
 
@@ -81,7 +82,7 @@ function useViews({ setToast, views, router, getViews }: useViewsProps) {
             });
           } else {
             setLoading(false);
-            getViews(true, view.name);
+            getViews(true, view.id.toString());
             setToast({
               hasError: false,
               title: `${view.name} has been created.`,
@@ -101,13 +102,14 @@ function useViews({ setToast, views, router, getViews }: useViewsProps) {
             });
           } else {
             setLoading(false);
-            getViews(true, view.name);
+            getViews();
             setToast({
               hasError: false,
               title: `${view.name} has been created.`,
               message: `The custom view will now be accessible from the top navigation.`
             });
             closeModal();
+            router.push('/');
           }
         });
       }

--- a/dashboard/components/inventory/hooks/useInventory.tsx
+++ b/dashboard/components/inventory/hooks/useInventory.tsx
@@ -12,6 +12,9 @@ export type InventoryFilterDataProps = {
     | 'account'
     | 'name'
     | 'service'
+    | 'cost'
+    | 'tags'
+    | 'tag'
     | string
     | undefined;
   operator:

--- a/dashboard/components/inventory/hooks/useInventory.tsx
+++ b/dashboard/components/inventory/hooks/useInventory.tsx
@@ -61,7 +61,7 @@ export type InventoryItem = {
 export type Pages = 'tags' | 'delete';
 
 export type ViewProps = {
-  id?: number;
+  id: number;
   name: string;
   filters: InventoryFilterDataProps[];
   exclude: string[];
@@ -235,7 +235,7 @@ function useInventory() {
     setShouldFetchMore(false);
   }
 
-  function getViews(edit?: boolean, viewName?: string) {
+  function getViews(edit?: boolean, viewId?: string) {
     settingsService.getViews().then(res => {
       if (res === Error) {
         setToast({
@@ -244,9 +244,11 @@ function useInventory() {
           message: `There was a problem fetching the views. Please try again.`
         });
       } else {
-        setViews(res);
-        if (edit && viewName) {
-          router.push(`/?view=${viewName}`, undefined, { shallow: true });
+        const sortViewsById: ViewProps[] = res;
+        sortViewsById.sort((a, b) => a.id - b.id);
+        setViews(sortViewsById);
+        if (edit && viewId) {
+          router.push(`/?view=${viewId}`, undefined, { shallow: true });
         }
       }
     });
@@ -301,7 +303,9 @@ function useInventory() {
 
     // Fetch from a custom view
     if (router.query.view && views && views.length > 0) {
-      const filterFound = views.find(view => view.name === router.query.view);
+      const filterFound = views.find(
+        view => view.id.toString() === router.query.view
+      );
 
       if (filterFound) {
         setSearchedLoading(true);
@@ -515,7 +519,9 @@ function useInventory() {
       }
 
       if (router.query.view && views && views.length > 0) {
-        const filterFound = views.find(view => view.name === router.query.view);
+        const filterFound = views.find(
+          view => view.id.toString() === router.query.view
+        );
         payloadJson = JSON.stringify(filterFound?.filters);
       }
 
@@ -602,7 +608,9 @@ function useInventory() {
       router.query.view &&
       !query
     ) {
-      const filterFound = views.find(view => view.name === router.query.view);
+      const filterFound = views.find(
+        view => view.id.toString() === router.query.view
+      );
 
       if (filterFound) {
         const payloadJson = JSON.stringify(filterFound?.filters);
@@ -727,7 +735,9 @@ function useInventory() {
       }, 700);
     }
     if (router.query.view && views && views.length > 0) {
-      const filterFound = views.find(view => view.name === router.query.view);
+      const filterFound = views.find(
+        view => view.id.toString() === router.query.view
+      );
 
       if (filterFound) {
         const payloadJson = JSON.stringify(filterFound.filters);

--- a/dashboard/utils/regex.tsx
+++ b/dashboard/utils/regex.tsx
@@ -3,7 +3,8 @@ type Regex = { [key: string]: RegExp };
 const regex: Regex = {
   required: /./,
   email: /^[\w-\\.]+@([\w-]+\.)+[\w-]{2,4}$/,
-  password: /^(?=.*?[A-Z])(?=.*?[a-z])(?=.*?[0-9]).{8,}$/
+  password: /^(?=.*?[A-Z])(?=.*?[a-z])(?=.*?[0-9]).{8,}$/,
+  number: / \d+ /
 };
 
 export default regex;


### PR DESCRIPTION
### Description
- Added support to filtering resources by cost using the operators: equal, between, greater than & less than.
- Changed URL params for views to display view id and no longer view name (now supports the same name for multiple views).
- Minor fixes.

### Related Issue
- #274 

### Screenshots
<img width="1624" alt="image" src="https://user-images.githubusercontent.com/13384559/213733864-0b5990fc-889e-4b13-8da7-664d5a6562d6.png">
<img width="1624" alt="image" src="https://user-images.githubusercontent.com/13384559/213733946-b69ebb69-43c3-49f2-87f9-4aaf4b9351ab.png">
<img width="1624" alt="image" src="https://user-images.githubusercontent.com/13384559/213733966-c65866c8-6c45-44b9-9216-b208ed6198d4.png">
<img width="1624" alt="image" src="https://user-images.githubusercontent.com/13384559/213733992-d6c7905e-9b92-4a3b-a783-3bb38cfd89d3.png">
<img width="1624" alt="image" src="https://user-images.githubusercontent.com/13384559/213734070-b5cfebb3-664a-4139-8778-e46d68c6625e.png">

