### PR TITLE
add listen-address CLI flag

### DIFF
--- a/cmd/start.go
+++ b/cmd/start.go
@@ -34,12 +34,17 @@ var startCmd = &cobra.Command{
 			log.Info("Tracking has been disabled")
 		}
 
+		address, err := cmd.Flags().GetString("listen-address")
+		if err != nil {
+			return err
+		}
+
 		port, err := cmd.Flags().GetInt("port")
 		if err != nil {
 			return err
 		}
 
-		err = internal.Exec(port, file, noTracking, regions, cmd)
+		err = internal.Exec(address, port, file, noTracking, regions, cmd)
 		if err != nil {
 			return err
 		}
@@ -50,6 +55,7 @@ var startCmd = &cobra.Command{
 
 func init() {
 	rootCmd.AddCommand(startCmd)
+	startCmd.PersistentFlags().StringP("listen-address", "a", "0.0.0.0", `Listen address to start server on.`)
 	startCmd.PersistentFlags().Int("port", 3000, `Port to start server on, default:"3000".`)
 	startCmd.PersistentFlags().StringArray("regions", []string{}, "Restrict Komiser inspection to list of regions.")
 	startCmd.PersistentFlags().String("config", "config.toml", "Path to configuration file.")

--- a/internal/internal.go
+++ b/internal/internal.go
@@ -41,7 +41,7 @@ var Os = runtime.GOOS
 var Arch = runtime.GOARCH
 var db *bun.DB
 
-func Exec(port int, configPath string, noTracking bool, regions []string, cmd *cobra.Command) error {
+func Exec(address string, port int, configPath string, noTracking bool, regions []string, cmd *cobra.Command) error {
 	cfg, clients, err := config.Load(configPath)
 	if err != nil {
 		return err
@@ -66,7 +66,7 @@ func Exec(port int, configPath string, noTracking bool, regions []string, cmd *c
 
 	go checkUpgrade()
 
-	err = runServer(port, noTracking)
+	err = runServer(address, port, noTracking)
 	if err != nil {
 		return err
 	}
@@ -74,7 +74,7 @@ func Exec(port int, configPath string, noTracking bool, regions []string, cmd *c
 	return nil
 }
 
-func runServer(port int, noTracking bool) error {
+func runServer(address string, port int, noTracking bool) error {
 	log.Infof("Komiser version: %s, commit: %s, buildt: %s", Version, Commit, Buildtime)
 
 	r := v1.Endpoints(context.Background(), noTracking, db)
@@ -86,11 +86,11 @@ func runServer(port int, noTracking bool) error {
 	})
 
 	loggedRouter := handlers.LoggingHandler(os.Stdout, cors.Handler(r))
-	err := http.ListenAndServe(fmt.Sprintf(":%d", port), loggedRouter)
+	err := http.ListenAndServe(fmt.Sprintf("%s:%d", address, port), loggedRouter)
 	if err != nil {
 		return err
 	} else {
-		log.Info("Server started on port %d", port)
+		log.Info("Server started on %s:%d", address, port)
 	}
 
 	return nil


### PR DESCRIPTION
### Description
For running the Komiser without docker maybe useful run it on localhost or any preferable address for security reasons.
With this changes you can run the Komiser with CLI flag `--listen-address 127.0.0.1` (or `-a 127.0.0.1` short flag).
The default address is `0.0.0.0` for backwards compatibility.
