### PR TITLE
added nil pointer check to buckets.go

### DIFF
--- a/providers/aws/efs/efs.go
+++ b/providers/aws/efs/efs.go
@@ -34,34 +34,37 @@ func ElasticFileStorage(ctx context.Context, client ProviderClient) ([]Resource,
 		}
 
 		for _, filesystem := range output.FileSystems {
-			resourceArn := fmt.Sprintf("arn:aws:efs:%s:%s:file-systems/%s", client.AWSClient.Region, *accountId, *filesystem.Name)
-			outputTags, err := efsClient.ListTagsForResource(ctx, &efs.ListTagsForResourceInput{
-				ResourceId: &resourceArn,
-			})
+			if filesystem.Name != nil {
 
-			tags := make([]Tag, 0)
+				resourceArn := fmt.Sprintf("arn:aws:efs:%s:%s:file-systems/%s", client.AWSClient.Region, *accountId, *filesystem.Name)
+				outputTags, err := efsClient.ListTagsForResource(ctx, &efs.ListTagsForResourceInput{
+					ResourceId: &resourceArn,
+				})
 
-			if err == nil {
-				for _, tag := range outputTags.Tags {
-					tags = append(tags, Tag{
-						Key:   *tag.Key,
-						Value: *tag.Value,
-					})
+				tags := make([]Tag, 0)
+
+				if err == nil {
+					for _, tag := range outputTags.Tags {
+						tags = append(tags, Tag{
+							Key:   *tag.Key,
+							Value: *tag.Value,
+						})
+					}
 				}
-			}
 
-			resources = append(resources, Resource{
-				Provider:   "AWS",
-				Account:    client.Name,
-				Service:    "EFS",
-				ResourceId: resourceArn,
-				Region:     client.AWSClient.Region,
-				Name:       *filesystem.Name,
-				Cost:       0,
-				Tags:       tags,
-				FetchedAt:  time.Now(),
-				Link:       fmt.Sprintf("https://%s.console.aws.amazon.com/efs/home?region=%s#/file-systems/%s", client.AWSClient.Region, client.AWSClient.Region, *filesystem.Name),
-			})
+				resources = append(resources, Resource{
+					Provider:   "AWS",
+					Account:    client.Name,
+					Service:    "EFS",
+					ResourceId: resourceArn,
+					Region:     client.AWSClient.Region,
+					Name:       *filesystem.Name,
+					Cost:       0,
+					Tags:       tags,
+					FetchedAt:  time.Now(),
+					Link:       fmt.Sprintf("https://%s.console.aws.amazon.com/efs/home?region=%s#/file-systems/%s", client.AWSClient.Region, client.AWSClient.Region, *filesystem.Name),
+				})
+			}
 		}
 
 		if aws.ToString(output.NextMarker) == "" {

--- a/providers/aws/s3/buckets.go
+++ b/providers/aws/s3/buckets.go
@@ -62,8 +62,10 @@ func Buckets(ctx context.Context, client ProviderClient) ([]Resource, error) {
 			}
 
 			bucketSize := 0.0
-			if len(metricsBucketSizebytesOutput.Datapoints) > 0 {
-				bucketSize = *metricsBucketSizebytesOutput.Datapoints[0].Average
+			if metricsBucketSizebytesOutput != nil && len(metricsBucketSizebytesOutput.Datapoints) > 0 {
+				if err != nil {
+					bucketSize = *metricsBucketSizebytesOutput.Datapoints[0].Average
+				}
 			}
 
 			sizeInTB := ConvertBytesToTerabytes(int64(bucketSize))

--- a/providers/aws/s3/buckets.go
+++ b/providers/aws/s3/buckets.go
@@ -63,7 +63,6 @@ func Buckets(ctx context.Context, client ProviderClient) ([]Resource, error) {
 
 			bucketSize := 0.0
 			if metricsBucketSizebytesOutput != nil && len(metricsBucketSizebytesOutput.Datapoints) > 0 {
-				if err != nil {
 					bucketSize = *metricsBucketSizebytesOutput.Datapoints[0].Average
 				}
 			}

--- a/providers/aws/s3/buckets.go
+++ b/providers/aws/s3/buckets.go
@@ -63,8 +63,7 @@ func Buckets(ctx context.Context, client ProviderClient) ([]Resource, error) {
 
 			bucketSize := 0.0
 			if metricsBucketSizebytesOutput != nil && len(metricsBucketSizebytesOutput.Datapoints) > 0 {
-					bucketSize = *metricsBucketSizebytesOutput.Datapoints[0].Average
-				}
+				bucketSize = *metricsBucketSizebytesOutput.Datapoints[0].Average
 			}
 
 			sizeInTB := ConvertBytesToTerabytes(int64(bucketSize))


### PR DESCRIPTION
I added a couple of lines to check if the pointer (metricsBucketSizebytesOutput) is not nil, if the length of the slice is greater than zero and then check if there is an error.




