### PR TITLE
feat: hide/unhide resources from view

### DIFF
--- a/handlers/resources_handler.go
+++ b/handlers/resources_handler.go
@@ -244,6 +244,7 @@ func (handler *ApiHandler) FilterResourcesHandler(w http.ResponseWriter, r *http
 		if handler.db.Dialect().Name() == dialect.SQLite {
 			query = fmt.Sprintf("SELECT resources.id, resources.resource_id, resources.provider, resources.account, resources.service, resources.region, resources.name, resources.created_at, resources.fetched_at, resources.cost, resources.metadata, resources.tags, resources.link FROM resources CROSS JOIN json_each(tags) WHERE type='object' AND %s ORDER BY resources.id LIMIT %d OFFSET %d", whereClause, limit, skip)
 		}
+
 		handler.db.NewRaw(query).Scan(handler.ctx, &resources)
 	} else {
 		err = handler.db.NewRaw(fmt.Sprintf("SELECT * FROM resources WHERE %s ORDER BY id LIMIT %d OFFSET %d", whereClause, limit, skip)).Scan(handler.ctx, &resources)

--- a/internal/api/v1/endpoints.go
+++ b/internal/api/v1/endpoints.go
@@ -25,6 +25,9 @@ func Endpoints(ctx context.Context, noTracking bool, db *bun.DB) *mux.Router {
 	r.HandleFunc("/views/{id}", api.GetViewHandler).Methods("GET")
 	r.HandleFunc("/views/{id}", api.UpdateViewHandler).Methods("PUT")
 	r.HandleFunc("/views/{id}", api.DeleteViewHandler).Methods("DELETE")
+	r.HandleFunc("/views/{id}/resources/hide", api.HideResourcesFromViewHandler).Methods("POST")
+	r.HandleFunc("/views/{id}/resources/unhide", api.UnhideResourcesFromViewHandler).Methods("POST")
+	r.HandleFunc("/views/{id}/hidden/resources", api.ListHiddenResourcesHandler).Methods("GET")
 
 	r.HandleFunc("/regions", api.ListRegionsHandler)
 	r.HandleFunc("/providers", api.ListProvidersHandler)


### PR DESCRIPTION
### Description

Allow user to hide or unhide resources from a custom view. This can be useful to hide shared resources (K8s clusters, Databases, etc) from team/application views 
