### PR TITLE
Enable segment and sentry

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -86,7 +86,7 @@ jobs:
                 docker context create tls-env
                 docker buildx create tls-env --use
                 docker login -u$DOCKERHUB_LOGIN -p$DOCKERHUB_PASSWORD
-                docker buildx build --push --platform linux/amd64,linux/arm64 -t tailwarden/komiser:latest -t tailwarden/komiser:${CIRCLE_SHA1} -t tailwarden/komiser:3.0.2 .
+                docker buildx build --push --platform linux/amd64,linux/arm64 --build-arg SEGMENT_WRITE_KEY=$SEGMENT_WRITE_KEY -t tailwarden/komiser:latest -t tailwarden/komiser:${CIRCLE_SHA1} -t tailwarden/komiser:3.0.2 .
 
 workflows:
     version: 2

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,10 +1,12 @@
 FROM --platform=$BUILDPLATFORM alpine:3.16
 ARG TARGETPLATFORM
 ARG BUILDPLATFORM
+ARG SEGMENT_WRITE_KEY
 MAINTAINER mlabouardy <mohamed@tailwarden.com>
 
 RUN echo "Running on $BUILDPLATFORM, building for $TARGETPLATFORM" > /log
 
+ENV SEGMENT_WRITE_KEY $SEGMENT_WRITE_KEY
 ENV VERSION 3.0.2
 
 RUN apk update && apk add curl

--- a/cmd/start.go
+++ b/cmd/start.go
@@ -2,7 +2,11 @@ package cmd
 
 import (
 	"errors"
+	"os"
 
+	"github.com/getsentry/sentry-go"
+	"github.com/rs/xid"
+	"github.com/segmentio/analytics-go"
 	log "github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 	"github.com/tailwarden/komiser/internal"
@@ -29,9 +33,11 @@ var startCmd = &cobra.Command{
 		verbose, _ := cmd.Flags().GetBool("verbose")
 		setupLogging(verbose)
 
-		noTracking, _ := cmd.Flags().GetBool("no-tracking")
-		if noTracking {
-			log.Info("Tracking has been disabled")
+		telemetry, _ := cmd.Flags().GetBool("telemetry")
+		if !telemetry {
+			log.Info("Telemetry has been disabled")
+		} else {
+			enableTelemetry()
 		}
 
 		address, err := cmd.Flags().GetString("listen-address")
@@ -44,7 +50,7 @@ var startCmd = &cobra.Command{
 			return err
 		}
 
-		err = internal.Exec(address, port, file, noTracking, regions, cmd)
+		err = internal.Exec(address, port, file, telemetry, regions, cmd)
 		if err != nil {
 			return err
 		}
@@ -60,7 +66,7 @@ func init() {
 	startCmd.PersistentFlags().StringArray("regions", []string{}, "Restrict Komiser inspection to list of regions.")
 	startCmd.PersistentFlags().String("config", "config.toml", "Path to configuration file.")
 	startCmd.PersistentFlags().Bool("verbose", true, "Show verbose debug information.")
-	startCmd.PersistentFlags().Bool("no-tracking", false, "Disable user analytics.")
+	startCmd.PersistentFlags().Bool("telemetry", true, "Disable user analytics.")
 }
 
 func setupLogging(verbose bool) {
@@ -75,4 +81,26 @@ func setupLogging(verbose bool) {
 	} else {
 		log.SetLevel(log.InfoLevel)
 	}
+}
+
+func enableTelemetry() {
+	err := sentry.Init(sentry.ClientOptions{
+		Dsn:              "https://adb527b644304373a8b045474a9f19dc@o1267000.ingest.sentry.io/4504684284805120",
+		TracesSampleRate: 1.0,
+		Debug:            false,
+		Release:          "komiser@" + internal.Version,
+	})
+	if err != nil {
+		log.Fatalf("sentry.Init: %s", err)
+	}
+
+	if os.Getenv("SEGMENT_WRITE_KEY") != "" {
+		client := analytics.New(os.Getenv("SEGMENT_WRITE_KEY"))
+
+		client.Enqueue(analytics.Track{
+			UserId: xid.New().String(),
+			Event:  "engine_launched",
+		})
+	}
+
 }

--- a/go.mod
+++ b/go.mod
@@ -29,6 +29,7 @@ require (
 	github.com/civo/civogo v0.3.24
 	github.com/digitalocean/godo v1.88.0
 	github.com/elazarl/go-bindata-assetfs v1.0.1
+	github.com/getsentry/sentry-go v0.18.0
 	github.com/go-co-op/gocron v1.18.0
 	github.com/gorilla/handlers v1.5.1
 	github.com/gorilla/mux v1.8.0
@@ -36,6 +37,8 @@ require (
 	github.com/linode/linodego v1.12.0
 	github.com/oracle/oci-go-sdk v24.3.0+incompatible
 	github.com/rs/cors v1.8.2
+	github.com/rs/xid v1.4.0
+	github.com/segmentio/analytics-go v3.1.0+incompatible
 	github.com/sirupsen/logrus v1.9.0
 	github.com/siruspen/logrus v1.7.1
 	github.com/spf13/cobra v1.6.1
@@ -89,7 +92,7 @@ require (
 	github.com/josharian/intern v1.0.0 // indirect
 	github.com/json-iterator/go v1.1.12 // indirect
 	github.com/kballard/go-shellquote v0.0.0-20180428030007-95032a82bc51 // indirect
-	github.com/mailru/easyjson v0.7.6 // indirect
+	github.com/mailru/easyjson v0.7.7 // indirect
 	github.com/mattn/go-isatty v0.0.16 // indirect
 	github.com/mattn/go-sqlite3 v1.14.15 // indirect
 	github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd // indirect
@@ -97,10 +100,12 @@ require (
 	github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822 // indirect
 	github.com/remyoudompheng/bigfft v0.0.0-20200410134404-eec4a21b6bb0 // indirect
 	github.com/robfig/cron/v3 v3.0.1 // indirect
+	github.com/segmentio/backo-go v1.0.1 // indirect
 	github.com/spf13/pflag v1.0.5 // indirect
 	github.com/tmthrgd/go-hex v0.0.0-20190904060850-447a3041c3bc // indirect
 	github.com/vmihailenco/msgpack/v5 v5.3.5 // indirect
 	github.com/vmihailenco/tagparser/v2 v2.0.0 // indirect
+	github.com/xtgo/uuid v0.0.0-20140804021211-a0b114877d4c // indirect
 	golang.org/x/crypto v0.1.0 // indirect
 	golang.org/x/mod v0.6.0 // indirect
 	golang.org/x/net v0.5.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -200,6 +200,8 @@ github.com/felixge/httpsnoop v1.0.3 h1:s/nj+GCswXYzN5v2DpNMuMQYe+0DDwt5WVCU6CWBd
 github.com/felixge/httpsnoop v1.0.3/go.mod h1:m8KPJKqk1gH5J9DgRY2ASl2lWCfGKXixSwevea8zH2U=
 github.com/fsnotify/fsnotify v1.4.7/go.mod h1:jwhsz4b93w/PPRr/qN1Yymfu8t87LnFCMoQvtojpjFo=
 github.com/fsnotify/fsnotify v1.4.9/go.mod h1:znqG4EE+3YCdAaPaxE2ZRY/06pZUdp0tY4IgpuI1SZQ=
+github.com/getsentry/sentry-go v0.18.0 h1:MtBW5H9QgdcJabtZcuJG80BMOwaBpkRDZkxRkNC1sN0=
+github.com/getsentry/sentry-go v0.18.0/go.mod h1:Kgon4Mby+FJ7ZWHFUAZgVaIa8sxHtnRJRLTXZr51aKQ=
 github.com/ghodss/yaml v1.0.0/go.mod h1:4dBDuWmgqj2HViK6kFavaiC9ZROes6MMH2rRYeMEF04=
 github.com/go-co-op/gocron v1.18.0 h1:SxTyJ5xnSN4byCq7b10LmmszFdxQlSQJod8s3gbnXxA=
 github.com/go-co-op/gocron v1.18.0/go.mod h1:sD/a0Aadtw5CpflUJ/lpP9Vfdk979Wl1Sg33HPHg0FY=
@@ -363,6 +365,8 @@ github.com/mailru/easyjson v0.0.0-20190614124828-94de47d64c63/go.mod h1:C1wdFJiN
 github.com/mailru/easyjson v0.0.0-20190626092158-b2ccc519800e/go.mod h1:C1wdFJiN94OJF2b5HbByQZoLdCWB1Yqtg26g4irojpc=
 github.com/mailru/easyjson v0.7.6 h1:8yTIVnZgCoiM1TgqoeTl+LfU5Jg6/xL3QhGQnimLYnA=
 github.com/mailru/easyjson v0.7.6/go.mod h1:xzfreul335JAWq5oZzymOObrkdz5UnU4kGfJJLY9Nlc=
+github.com/mailru/easyjson v0.7.7 h1:UGYAvKxe3sBsEDzO8ZeWOSlIQfWFlxbzLZe7hwFURr0=
+github.com/mailru/easyjson v0.7.7/go.mod h1:xzfreul335JAWq5oZzymOObrkdz5UnU4kGfJJLY9Nlc=
 github.com/mattn/go-isatty v0.0.12/go.mod h1:cbi8OIDigv2wuxKPP5vlRcQ1OAZbq2CE4Kysco4FUpU=
 github.com/mattn/go-isatty v0.0.16 h1:bq3VjFmv/sOjHtdEhmkEV4x1AJtvUvOJ2PFAZ5+peKQ=
 github.com/mattn/go-isatty v0.0.16/go.mod h1:kYGgaQfpe5nmfYZH+SKPsOc2e4SrIfOl2e/yFXSvRLM=
@@ -418,7 +422,13 @@ github.com/rogpeppe/fastuuid v1.2.0/go.mod h1:jVj6XXZzXRy/MSR5jhDC/2q6DgLz+nrA6L
 github.com/rogpeppe/go-internal v1.3.0/go.mod h1:M8bDsm7K2OlrFYOpmOWEs/qY81heoFRclV5y23lUDJ4=
 github.com/rs/cors v1.8.2 h1:KCooALfAYGs415Cwu5ABvv9n9509fSiG5SQJn/AQo4U=
 github.com/rs/cors v1.8.2/go.mod h1:XyqrcTp5zjWr1wsJ8PIRZssZ8b/WMcMf71DJnit4EMU=
+github.com/rs/xid v1.4.0 h1:qd7wPTDkN6KQx2VmMBLrpHkiyQwgFXRnkOLacUiaSNY=
+github.com/rs/xid v1.4.0/go.mod h1:trrq9SKmegXys3aeAKXMUTdJsYXVwGY3RLcfgqegfbg=
 github.com/russross/blackfriday/v2 v2.1.0/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=
+github.com/segmentio/analytics-go v3.1.0+incompatible h1:IyiOfUgQFVHvsykKKbdI7ZsH374uv3/DfZUo9+G0Z80=
+github.com/segmentio/analytics-go v3.1.0+incompatible/go.mod h1:C7CYBtQWk4vRk2RyLu0qOcbHJ18E3F1HV2C/8JvKN48=
+github.com/segmentio/backo-go v1.0.1 h1:68RQccglxZeyURy93ASB/2kc9QudzgIDexJ927N++y4=
+github.com/segmentio/backo-go v1.0.1/go.mod h1:9/Rh6yILuLysoQnZ2oNooD2g7aBnvM7r/fNVxRNWfBc=
 github.com/sirupsen/logrus v1.9.0 h1:trlNQbNUG3OdDrDil03MCb1H2o9nJ1x4/5LYw7byDE0=
 github.com/sirupsen/logrus v1.9.0/go.mod h1:naHLuLoDiP4jHNo9R0sCBMtWGeIprob74mVsIT4qYEQ=
 github.com/siruspen/logrus v1.7.1 h1:IMmhpka8uZtqUMfoDNroMx2R5XPmZMqI6j9hzxNEJns=
@@ -463,6 +473,8 @@ github.com/vmihailenco/msgpack/v5 v5.3.5 h1:5gO0H1iULLWGhs2H5tbAHIZTV8/cYafcFOr9
 github.com/vmihailenco/msgpack/v5 v5.3.5/go.mod h1:7xyJ9e+0+9SaZT0Wt1RGleJXzli6Q/V5KbhBonMG9jc=
 github.com/vmihailenco/tagparser/v2 v2.0.0 h1:y09buUbR+b5aycVFQs/g70pqKVZNBmxwAhO7/IwNM9g=
 github.com/vmihailenco/tagparser/v2 v2.0.0/go.mod h1:Wri+At7QHww0WTrCBeu4J6bNtoV6mEfg5OIWRZA9qds=
+github.com/xtgo/uuid v0.0.0-20140804021211-a0b114877d4c h1:3lbZUMbMiGUW/LMkfsEABsc5zNT9+b1CvsJx47JzJ8g=
+github.com/xtgo/uuid v0.0.0-20140804021211-a0b114877d4c/go.mod h1:UrdRz5enIKZ63MEE3IF9l2/ebyx59GyGgPi+tICQdmM=
 github.com/yuin/goldmark v1.1.25/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
 github.com/yuin/goldmark v1.1.27/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
 github.com/yuin/goldmark v1.1.32/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=

--- a/internal/api/v1/endpoints.go
+++ b/internal/api/v1/endpoints.go
@@ -9,10 +9,10 @@ import (
 	"github.com/uptrace/bun"
 )
 
-func Endpoints(ctx context.Context, noTracking bool, db *bun.DB) *mux.Router {
+func Endpoints(ctx context.Context, telemetry bool, db *bun.DB) *mux.Router {
 	r := mux.NewRouter()
 
-	api := handlers.NewApiHandler(ctx, noTracking, db)
+	api := handlers.NewApiHandler(ctx, telemetry, db)
 
 	r.HandleFunc("/resources", api.ListResourcesHandler)
 	r.HandleFunc("/resources/search", api.FilterResourcesHandler).Methods("POST")

--- a/internal/internal.go
+++ b/internal/internal.go
@@ -43,7 +43,7 @@ var Os = runtime.GOOS
 var Arch = runtime.GOARCH
 var db *bun.DB
 
-func Exec(address string, port int, configPath string, noTracking bool, regions []string, cmd *cobra.Command) error {
+func Exec(address string, port int, configPath string, telemetry bool, regions []string, cmd *cobra.Command) error {
 	cfg, clients, err := config.Load(configPath)
 	if err != nil {
 		return err
@@ -68,7 +68,7 @@ func Exec(address string, port int, configPath string, noTracking bool, regions 
 
 	go checkUpgrade()
 
-	err = runServer(address, port, noTracking)
+	err = runServer(address, port, telemetry)
 	if err != nil {
 		return err
 	}
@@ -76,10 +76,10 @@ func Exec(address string, port int, configPath string, noTracking bool, regions 
 	return nil
 }
 
-func runServer(address string, port int, noTracking bool) error {
+func runServer(address string, port int, telemetry bool) error {
 	log.Infof("Komiser version: %s, commit: %s, buildt: %s", Version, Commit, Buildtime)
 
-	r := v1.Endpoints(context.Background(), noTracking, db)
+	r := v1.Endpoints(context.Background(), telemetry, db)
 
 	cors := cors.New(cors.Options{
 		AllowedOrigins: []string{"*"},


### PR DESCRIPTION
### Description

We collect telemetry data for only two reasons: so that we can improve our product, and so that we can continue working on this project full-time.

In order to create a better product, we need reliable quantitative information. The data we collect helps us fix bugs, evaluate the success of features, and better understand our users' needs.

We also need to prove that people are actually using Komiser. Usage metrics help us justify our existence to investors so that we can keep this project alive

### Changes

By default, the Komiser CLI collects some anonymous usage data. There are two types of data we collect: errors and stats. We use Sentry to collect errors and performance issues. While Segment is used to track product usage.

PS: Komiser will not collect any cloud provider information or credentials :)

Documentation has been updated as well [here](https://github.com/tailwarden/docs.komiser.io/pull/42)