### PR TITLE
feat: expose dashboard stats

### DIFF
--- a/handlers/dashboard_handler.go
+++ b/handlers/dashboard_handler.go
@@ -1,0 +1,45 @@
+package handlers
+
+import (
+	"net/http"
+)
+
+func (handler *ApiHandler) DashboardStatsHandler(w http.ResponseWriter, r *http.Request) {
+	regions := struct {
+		Count int `bun:"count" json:"total"`
+	}{}
+
+	handler.db.NewRaw("SELECT COUNT(*) as count FROM (SELECT DISTINCT region FROM resources) AS temp").Scan(handler.ctx, &regions)
+
+	resources := struct {
+		Count int `bun:"count" json:"total"`
+	}{}
+
+	handler.db.NewRaw("SELECT COUNT(*) as count FROM resources").Scan(handler.ctx, &resources)
+
+	cost := struct {
+		Sum float64 `bun:"sum" json:"total"`
+	}{}
+
+	handler.db.NewRaw("SELECT SUM(cost) as sum FROM resources").Scan(handler.ctx, &cost)
+
+	accounts := struct {
+		Count int `bun:"count" json:"total"`
+	}{}
+
+	handler.db.NewRaw("SELECT COUNT(*) as count FROM (SELECT DISTINCT account FROM resources) AS temp").Scan(handler.ctx, &accounts)
+
+	output := struct {
+		Resources int     `json:"resources"`
+		Regions   int     `json:"regions"`
+		Costs     float64 `json:"costs"`
+		Accounts  int     `json:"accounts"`
+	}{
+		Resources: resources.Count,
+		Regions:   regions.Count,
+		Costs:     cost.Sum,
+		Accounts:  accounts.Count,
+	}
+
+	respondWithJSON(w, 200, output)
+}

--- a/internal/api/v1/endpoints.go
+++ b/internal/api/v1/endpoints.go
@@ -36,6 +36,7 @@ func Endpoints(ctx context.Context, telemetry bool, db *bun.DB) *mux.Router {
 	r.HandleFunc("/accounts", api.ListAccountsHandler)
 	r.HandleFunc("/costs", api.CostCounterHandler)
 	r.HandleFunc("/stats", api.StatsHandler)
+	r.HandleFunc("/global/stats", api.DashboardStatsHandler)
 	r.HandleFunc("/stats/search", api.FilterStatsHandler).Methods("POST")
 	r.HandleFunc("/tracking", api.EnableTrackingHandler)
 


### PR DESCRIPTION
### Changes proposed 

Exposed an endpoint with the following stats:

- Number of connected cloud accounts
- Number of active regions
- Up-to-date monthly cost
- Number of cloud resources