### PR TITLE
Cost explorer widget + API plugged for Cloud Map & Resources Manager

### DIFF
--- a/dashboard/components/dashboard/components/cloud-map/hooks/useCloudMap.tsx
+++ b/dashboard/components/dashboard/components/cloud-map/hooks/useCloudMap.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useState } from 'react';
-import mockDataForDashboard from '../../../utils/mockDataForDashboard';
+import settingsService from '../../../../../services/settingsService';
 
 export type DashboardCloudMapRegions = {
   name: string;
@@ -23,10 +23,15 @@ function useCloudMap() {
       setError(false);
     }
 
-    setTimeout(() => {
-      setData(mockDataForDashboard.regions);
-      setLoading(false);
-    }, 1500);
+    settingsService.getGlobalLocations().then(res => {
+      if (res === Error) {
+        setLoading(false);
+        setError(true);
+      } else {
+        setLoading(false);
+        setData(res);
+      }
+    });
   }
 
   useEffect(() => {

--- a/dashboard/components/dashboard/components/cost-explorer/DashboardCostExplorer.tsx
+++ b/dashboard/components/dashboard/components/cost-explorer/DashboardCostExplorer.tsx
@@ -1,4 +1,5 @@
 import DashboardCostExplorerCard from './DashboardCostExplorerCard';
+import DashboardCostExplorerSkeleton from './DashboardCostExplorerSkeleton';
 import useCostExplorer from './hooks/useCostExplorer';
 
 function DashboardCostExplorer() {
@@ -15,7 +16,7 @@ function DashboardCostExplorer() {
     setQueryDate
   } = useCostExplorer();
 
-  if (loading) return <>Loading</>;
+  if (loading) return <DashboardCostExplorerSkeleton />;
 
   if (error) return <>Error</>;
 

--- a/dashboard/components/dashboard/components/cost-explorer/DashboardCostExplorer.tsx
+++ b/dashboard/components/dashboard/components/cost-explorer/DashboardCostExplorer.tsx
@@ -1,0 +1,35 @@
+import DashboardCostExplorerCard from './DashboardCostExplorerCard';
+import useCostExplorer from './hooks/useCostExplorer';
+
+function DashboardCostExplorer() {
+  const {
+    loading,
+    data,
+    error,
+    fetch,
+    queryGroup,
+    setQueryGroup,
+    queryGranularity,
+    setQueryGranularity,
+    queryDate,
+    setQueryDate
+  } = useCostExplorer();
+
+  if (loading) return <>Loading</>;
+
+  if (error) return <>Error</>;
+
+  return (
+    <DashboardCostExplorerCard
+      data={data}
+      queryGroup={queryGroup}
+      setQueryGroup={setQueryGroup}
+      queryGranularity={queryGranularity}
+      setQueryGranularity={setQueryGranularity}
+      queryDate={queryDate}
+      setQueryDate={setQueryDate}
+    />
+  );
+}
+
+export default DashboardCostExplorer;

--- a/dashboard/components/dashboard/components/cost-explorer/DashboardCostExplorer.tsx
+++ b/dashboard/components/dashboard/components/cost-explorer/DashboardCostExplorer.tsx
@@ -1,4 +1,5 @@
 import DashboardCostExplorerCard from './DashboardCostExplorerCard';
+import DashboardCostExplorerError from './DashboardCostExplorerError';
 import DashboardCostExplorerSkeleton from './DashboardCostExplorerSkeleton';
 import useCostExplorer from './hooks/useCostExplorer';
 
@@ -18,7 +19,7 @@ function DashboardCostExplorer() {
 
   if (loading) return <DashboardCostExplorerSkeleton />;
 
-  if (error) return <>Error</>;
+  if (error) return <DashboardCostExplorerError fetch={fetch} />;
 
   return (
     <DashboardCostExplorerCard

--- a/dashboard/components/dashboard/components/cost-explorer/DashboardCostExplorerCard.tsx
+++ b/dashboard/components/dashboard/components/cost-explorer/DashboardCostExplorerCard.tsx
@@ -1,0 +1,106 @@
+import {
+  Chart as ChartJS,
+  CategoryScale,
+  LinearScale,
+  BarElement,
+  Title,
+  Tooltip,
+  Legend
+} from 'chart.js';
+import { Dispatch, SetStateAction } from 'react';
+import { Bar } from 'react-chartjs-2';
+import Select from '../select/Select';
+import {
+  CostExplorerQueryDateProps,
+  CostExplorerQueryGranularityProps,
+  CostExplorerQueryGroupProps,
+  DashboardCostExplorerData
+} from './hooks/useCostExplorer';
+import useCostExplorerChart from './hooks/useCostExplorerChart';
+
+ChartJS.register(
+  CategoryScale,
+  LinearScale,
+  BarElement,
+  Title,
+  Tooltip,
+  Legend
+);
+
+type DashboardCostExplorerCardProps = {
+  data: DashboardCostExplorerData | undefined;
+  queryGroup: CostExplorerQueryGroupProps;
+  setQueryGroup: Dispatch<SetStateAction<CostExplorerQueryGroupProps>>;
+  queryGranularity: CostExplorerQueryGranularityProps;
+  setQueryGranularity: Dispatch<
+    SetStateAction<CostExplorerQueryGranularityProps>
+  >;
+  queryDate: CostExplorerQueryDateProps;
+  setQueryDate: Dispatch<SetStateAction<CostExplorerQueryDateProps>>;
+};
+
+function DashboardCostExplorerCard({
+  data,
+  queryGroup,
+  setQueryGroup,
+  queryGranularity,
+  setQueryGranularity,
+  queryDate,
+  setQueryDate
+}: DashboardCostExplorerCardProps) {
+  const {
+    chartData,
+    options,
+    groupBySelect,
+    granularitySelect,
+    dateSelect,
+    handleFilterChange
+  } = useCostExplorerChart({
+    data,
+    setQueryGroup,
+    queryGranularity,
+    setQueryGranularity,
+    setQueryDate
+  });
+
+  return (
+    <div className="w-full rounded-lg bg-white py-4 px-6 pb-6">
+      <div className=" -mx-6 flex flex-wrap items-center justify-between gap-4 border-b border-black-200/40 px-6 pb-4">
+        <div>
+          <p className="text-sm font-semibold text-black-900">Cost explorer</p>
+          <div className="mt-1"></div>
+          <p className="text-xs text-black-300">Navigate through costs</p>
+        </div>
+        <div className="flex w-full flex-col gap-4 md:w-auto md:flex-row">
+          <Select
+            label="Group by"
+            options={groupBySelect.values}
+            value={queryGroup}
+            displayValues={groupBySelect.displayValues}
+            onChange={e => handleFilterChange(e, 'group')}
+          />
+          <Select
+            label="Granularity"
+            options={granularitySelect.values}
+            value={queryGranularity}
+            displayValues={granularitySelect.displayValues}
+            onChange={e => handleFilterChange(e, 'granularity')}
+          />
+          <Select
+            label="Period"
+            options={dateSelect.values}
+            value={queryDate}
+            displayValues={dateSelect.displayValues}
+            onChange={e => handleFilterChange(e, 'date')}
+          />
+        </div>
+      </div>
+      <div className="mt-8"></div>
+      <div className="h-full min-h-[22rem]">
+        {chartData && <Bar data={chartData} options={options} />}
+      </div>
+    </div>
+  );
+}
+
+export default DashboardCostExplorerCard;

--- a/dashboard/components/dashboard/components/cost-explorer/DashboardCostExplorerCard.tsx
+++ b/dashboard/components/dashboard/components/cost-explorer/DashboardCostExplorerCard.tsx
@@ -69,7 +69,10 @@ function DashboardCostExplorerCard({
         <div>
           <p className="text-sm font-semibold text-black-900">Cost explorer</p>
           <div className="mt-1"></div>
-          <p className="text-xs text-black-300">Navigate through costs</p>
+          <p className="text-xs text-black-300">
+            Visualise, understand, and manage your infrastructure costs and
+            usage
+          </p>
         </div>
         <div className="flex w-full flex-col gap-4 md:w-auto md:flex-row">
           <Select

--- a/dashboard/components/dashboard/components/cost-explorer/DashboardCostExplorerError.tsx
+++ b/dashboard/components/dashboard/components/cost-explorer/DashboardCostExplorerError.tsx
@@ -1,0 +1,83 @@
+import Button from '../../../button/Button';
+import {
+  CostExplorerQueryGranularityProps,
+  CostExplorerQueryGroupProps
+} from './hooks/useCostExplorer';
+
+type DashboardCostExplorerErrorProps = {
+  fetch: (
+    provider?: CostExplorerQueryGroupProps,
+    granularity?: CostExplorerQueryGranularityProps,
+    startDate?: string,
+    endDate?: string
+  ) => void;
+};
+
+function DashboardCostExplorerError({
+  fetch
+}: DashboardCostExplorerErrorProps) {
+  const rows: number[] = Array.from(Array(8).keys());
+
+  return (
+    <div className="w-full rounded-lg bg-white py-4 px-6 pb-6">
+      <div className="-mx-6 flex items-center justify-center gap-6 border-b border-black-200/40 px-6 pb-4">
+        <p className="text-sm text-black-400">
+          There was an error loading the resources manager.
+        </p>
+        <div className="flex-shrink-0">
+          <Button style="outline" size="sm" onClick={() => fetch()}>
+            <svg
+              xmlns="http://www.w3.org/2000/svg"
+              width="16"
+              height="16"
+              fill="none"
+              viewBox="0 0 24 24"
+            >
+              <path
+                stroke="currentColor"
+                strokeLinecap="round"
+                strokeLinejoin="round"
+                strokeWidth="1.5"
+                d="M22 12c0 5.52-4.48 10-10 10s-8.89-5.56-8.89-5.56m0 0h4.52m-4.52 0v5M2 12C2 6.48 6.44 2 12 2c6.67 0 10 5.56 10 5.56m0 0v-5m0 5h-4.44"
+              ></path>
+            </svg>
+            Try again
+          </Button>
+        </div>
+        <div className="h-[60px]"></div>
+      </div>
+      <div className="mt-8"></div>
+      <div className="h-[22rem]">
+        <table className="h-[90%] w-full table-auto">
+          <tbody>
+            {rows.map(idx => (
+              <tr key={idx}>
+                <td className="border-black-150 border"></td>
+                <td className="border-black-150 border"></td>
+                <td className="border-black-150 border"></td>
+                <td className="border-black-150 border"></td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+        <div className="mt-4"></div>
+        <div className="flex justify-center gap-8">
+          <div className="flex items-center gap-2">
+            <div className="h-5 w-5 rounded-full bg-black-200/50"></div>
+            <div className="h-3 w-24 rounded-lg bg-black-200/50"></div>
+          </div>
+          <div className="flex items-center gap-2">
+            <div className="h-5 w-5 rounded-full bg-black-200/50"></div>
+            <div className="h-3 w-12 rounded-lg bg-black-200/50"></div>
+          </div>
+          <div className="flex items-center gap-2">
+            <div className="h-5 w-5 rounded-full bg-black-200/50"></div>
+            <div className="h-3 w-36 rounded-lg bg-black-200/50"></div>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+export default DashboardCostExplorerError;

--- a/dashboard/components/dashboard/components/cost-explorer/DashboardCostExplorerError.tsx
+++ b/dashboard/components/dashboard/components/cost-explorer/DashboardCostExplorerError.tsx
@@ -22,7 +22,7 @@ function DashboardCostExplorerError({
     <div className="w-full rounded-lg bg-white py-4 px-6 pb-6">
       <div className="-mx-6 flex items-center justify-center gap-6 border-b border-black-200/40 px-6 pb-4">
         <p className="text-sm text-black-400">
-          There was an error loading the resources manager.
+          There was an error loading the cost explorer.
         </p>
         <div className="flex-shrink-0">
           <Button style="outline" size="sm" onClick={() => fetch()}>

--- a/dashboard/components/dashboard/components/cost-explorer/DashboardCostExplorerSkeleton.tsx
+++ b/dashboard/components/dashboard/components/cost-explorer/DashboardCostExplorerSkeleton.tsx
@@ -9,9 +9,9 @@ function DashboardCostExplorerSkeleton() {
           <div className="h-3 w-36 rounded-lg bg-komiser-200/50"></div>
         </div>
         <div className="flex flex-col gap-4 px-6 pb-4 md:flex-row md:flex-wrap">
-          <div className="h-[60px] w-48 rounded-lg bg-komiser-200/50"></div>
-          <div className="h-[60px] w-48 rounded-lg bg-komiser-200/50"></div>
-          <div className="h-[60px] w-48 rounded-lg bg-komiser-200/50"></div>
+          <div className="h-[60px] w-[177.5px] rounded-lg bg-komiser-200/50"></div>
+          <div className="h-[60px] w-[177.5px] rounded-lg bg-komiser-200/50"></div>
+          <div className="h-[60px] w-[177.5px] rounded-lg bg-komiser-200/50"></div>
         </div>
       </div>
       <div className="mt-8"></div>

--- a/dashboard/components/dashboard/components/cost-explorer/DashboardCostExplorerSkeleton.tsx
+++ b/dashboard/components/dashboard/components/cost-explorer/DashboardCostExplorerSkeleton.tsx
@@ -1,0 +1,51 @@
+function DashboardCostExplorerSkeleton() {
+  const rows: number[] = Array.from(Array(8).keys());
+  return (
+    <div className="w-full animate-pulse rounded-lg bg-white py-4 px-6 pb-6">
+      <div className="-mx-6 flex flex-wrap items-center justify-between border-b border-black-200/40">
+        <div className="px-6 pb-4">
+          <div className="h-3 w-24 rounded-lg bg-komiser-200/50"></div>
+          <div className="mt-2"></div>
+          <div className="h-3 w-36 rounded-lg bg-komiser-200/50"></div>
+        </div>
+        <div className="flex flex-col gap-4 px-6 pb-4 md:flex-row md:flex-wrap">
+          <div className="h-[60px] w-48 rounded-lg bg-komiser-200/50"></div>
+          <div className="h-[60px] w-48 rounded-lg bg-komiser-200/50"></div>
+          <div className="h-[60px] w-48 rounded-lg bg-komiser-200/50"></div>
+        </div>
+      </div>
+      <div className="mt-8"></div>
+      <div className="h-[22rem]">
+        <table className="h-[90%] w-full table-auto">
+          <tbody>
+            {rows.map(idx => (
+              <tr key={idx}>
+                <td className="border-black-150 border"></td>
+                <td className="border-black-150 border"></td>
+                <td className="border-black-150 border"></td>
+                <td className="border-black-150 border"></td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+        <div className="mt-4"></div>
+        <div className="flex justify-center gap-8">
+          <div className="flex items-center gap-2">
+            <div className="h-5 w-5 rounded-full bg-komiser-200/50"></div>
+            <div className="h-3 w-24 rounded-lg bg-komiser-200/50"></div>
+          </div>
+          <div className="flex items-center gap-2">
+            <div className="h-5 w-5 rounded-full bg-komiser-200/50"></div>
+            <div className="h-3 w-12 rounded-lg bg-komiser-200/50"></div>
+          </div>
+          <div className="flex items-center gap-2">
+            <div className="h-5 w-5 rounded-full bg-komiser-200/50"></div>
+            <div className="h-3 w-36 rounded-lg bg-komiser-200/50"></div>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+export default DashboardCostExplorerSkeleton;

--- a/dashboard/components/dashboard/components/cost-explorer/hooks/useCostExplorer.tsx
+++ b/dashboard/components/dashboard/components/cost-explorer/hooks/useCostExplorer.tsx
@@ -1,0 +1,96 @@
+import { useEffect, useState } from 'react';
+import mockDataForDashboard from '../../../utils/mockDataForDashboard';
+import {
+  lastMonth,
+  lastSixMonths,
+  lastThreeMonths,
+  lastTwelveMonths
+} from '../utils/dateHelper';
+
+export type DashboardCostExplorerData = {
+  date: string;
+  datapoints: {
+    name: string;
+    amount: number;
+  }[];
+}[];
+
+export type CostExplorerQueryGroupProps =
+  | 'provider'
+  | 'service'
+  | 'region'
+  | 'account'
+  | 'view';
+export type CostExplorerQueryGranularityProps = 'monthly' | 'daily';
+export type CostExplorerQueryDateProps =
+  | 'lastMonth'
+  | 'lastThreeMonths'
+  | 'lastSixMonths'
+  | 'lastTwelveMonths';
+
+function useCostExplorer() {
+  const [loading, setLoading] = useState(true);
+  const [data, setData] = useState<DashboardCostExplorerData>();
+  const [error, setError] = useState(false);
+  const [queryGroup, setQueryGroup] =
+    useState<CostExplorerQueryGroupProps>('provider');
+  const [queryGranularity, setQueryGranularity] =
+    useState<CostExplorerQueryGranularityProps>('monthly');
+  const [queryDate, setQueryDate] =
+    useState<CostExplorerQueryDateProps>('lastSixMonths');
+
+  function fetch(
+    provider: CostExplorerQueryGroupProps,
+    granularity: CostExplorerQueryGranularityProps,
+    startDate: string,
+    endDate: string
+  ) {
+    if (!loading) {
+      setLoading(true);
+    }
+
+    if (error) {
+      setError(false);
+    }
+
+    setTimeout(() => {
+      setData(mockDataForDashboard.costs);
+      setLoading(false);
+    }, 1500);
+  }
+
+  useEffect(() => {
+    let startDate = '';
+    let endDate = '';
+
+    if (queryDate === 'lastMonth') {
+      [startDate, endDate] = lastMonth;
+    }
+    if (queryDate === 'lastThreeMonths') {
+      [startDate, endDate] = lastThreeMonths;
+    }
+    if (queryDate === 'lastSixMonths') {
+      [startDate, endDate] = lastSixMonths;
+    }
+    if (queryDate === 'lastTwelveMonths') {
+      [startDate, endDate] = lastTwelveMonths;
+    }
+
+    fetch(queryGroup, queryGranularity, startDate, endDate);
+  }, [queryGroup, queryGranularity, queryDate]);
+
+  return {
+    loading,
+    data,
+    error,
+    fetch,
+    queryGroup,
+    setQueryGroup,
+    queryGranularity,
+    setQueryGranularity,
+    queryDate,
+    setQueryDate
+  };
+}
+
+export default useCostExplorer;

--- a/dashboard/components/dashboard/components/cost-explorer/hooks/useCostExplorer.tsx
+++ b/dashboard/components/dashboard/components/cost-explorer/hooks/useCostExplorer.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useState } from 'react';
 import mockDataForDashboard from '../../../utils/mockDataForDashboard';
-import {
+import dateHelper, {
   lastMonth,
   lastSixMonths,
   lastThreeMonths,
@@ -31,7 +31,7 @@ export type CostExplorerQueryDateProps =
 function useCostExplorer() {
   const [loading, setLoading] = useState(true);
   const [data, setData] = useState<DashboardCostExplorerData>();
-  const [error, setError] = useState(false);
+  const [error, setError] = useState(true);
   const [queryGroup, setQueryGroup] =
     useState<CostExplorerQueryGroupProps>('provider');
   const [queryGranularity, setQueryGranularity] =
@@ -40,17 +40,17 @@ function useCostExplorer() {
     useState<CostExplorerQueryDateProps>('lastSixMonths');
 
   function fetch(
-    provider: CostExplorerQueryGroupProps,
-    granularity: CostExplorerQueryGranularityProps,
-    startDate: string,
-    endDate: string
+    provider: CostExplorerQueryGroupProps = 'provider',
+    granularity: CostExplorerQueryGranularityProps = 'monthly',
+    startDate: string = dateHelper.getLastSixMonths(),
+    endDate: string = dateHelper.getToday()
   ) {
     if (!loading) {
       setLoading(true);
     }
 
     if (error) {
-      setError(false);
+      // setError(false);
     }
 
     setTimeout(() => {

--- a/dashboard/components/dashboard/components/cost-explorer/hooks/useCostExplorer.tsx
+++ b/dashboard/components/dashboard/components/cost-explorer/hooks/useCostExplorer.tsx
@@ -31,7 +31,7 @@ export type CostExplorerQueryDateProps =
 function useCostExplorer() {
   const [loading, setLoading] = useState(true);
   const [data, setData] = useState<DashboardCostExplorerData>();
-  const [error, setError] = useState(true);
+  const [error, setError] = useState(false);
   const [queryGroup, setQueryGroup] =
     useState<CostExplorerQueryGroupProps>('provider');
   const [queryGranularity, setQueryGranularity] =
@@ -50,7 +50,7 @@ function useCostExplorer() {
     }
 
     if (error) {
-      // setError(false);
+      setError(false);
     }
 
     setTimeout(() => {

--- a/dashboard/components/dashboard/components/cost-explorer/hooks/useCostExplorerChart.tsx
+++ b/dashboard/components/dashboard/components/cost-explorer/hooks/useCostExplorerChart.tsx
@@ -1,0 +1,273 @@
+import { ChartData, ChartOptions } from 'chart.js';
+import {
+  ChangeEvent,
+  Dispatch,
+  SetStateAction,
+  useEffect,
+  useState
+} from 'react';
+import formatNumber from '../../../../../utils/formatNumber';
+import { dateFormatter } from '../utils/dateHelper';
+import {
+  CostExplorerQueryDateProps,
+  CostExplorerQueryGranularityProps,
+  CostExplorerQueryGroupProps,
+  DashboardCostExplorerData
+} from './useCostExplorer';
+
+type CostExplorerDatapointsProps = {
+  name: string;
+  amount: number;
+};
+
+type CostExplorerDataProps = {
+  date: string;
+  datapoints: CostExplorerDatapointsProps[];
+};
+
+export type GroupBySelectProps = {
+  values: string[];
+  displayValues: string[];
+};
+
+type useCostExplorerChartProps = {
+  data: DashboardCostExplorerData | undefined;
+  setQueryGroup: Dispatch<SetStateAction<CostExplorerQueryGroupProps>>;
+  queryGranularity: CostExplorerQueryGranularityProps;
+  setQueryGranularity: Dispatch<
+    SetStateAction<CostExplorerQueryGranularityProps>
+  >;
+  setQueryDate: Dispatch<SetStateAction<CostExplorerQueryDateProps>>;
+};
+
+function useCostExplorerChart({
+  data,
+  setQueryGroup,
+  queryGranularity,
+  setQueryGranularity,
+  setQueryDate
+}: useCostExplorerChartProps) {
+  const [chartData, setChartData] = useState<ChartData<'bar'>>();
+
+  const colors = ['#80AAF2', '#F19B6E', '#FBC864', '#9BD6CC', '#B8D987'];
+  const groupBySelect: GroupBySelectProps = {
+    values: ['provider', 'service', 'region', 'account', 'view'],
+    displayValues: [
+      'Cloud provider',
+      'Cloud service',
+      'Cloud region',
+      'Cloud account',
+      'Custom view'
+    ]
+  };
+  const granularitySelect: GroupBySelectProps = {
+    values: ['monthly', 'daily'],
+    displayValues: ['Monthly view', 'Daily view']
+  };
+
+  const dateSelect = {
+    values: [
+      'lastMonth',
+      'lastThreeMonths',
+      'lastSixMonths',
+      'lastTwelveMonths'
+    ],
+    displayValues: [
+      'Last month',
+      'Last 3 months',
+      'Last 6 months',
+      'Last 12 months'
+    ]
+  };
+
+  const options: ChartOptions<'bar'> = {
+    maintainAspectRatio: false,
+    interaction: {
+      intersect: false,
+      mode: 'index'
+    },
+    plugins: {
+      legend: {
+        position: 'bottom',
+        labels: {
+          color: '#635972',
+          font: {
+            family: 'Noto Sans'
+          },
+          usePointStyle: true,
+          padding: 24
+        }
+      },
+      tooltip: {
+        position: 'nearest',
+        xAlign: 'center',
+        yAlign: 'bottom',
+        usePointStyle: true,
+        backgroundColor: 'rgba(0,0,0,.75)',
+        boxPadding: 8,
+        padding: 16,
+        titleMarginBottom: 16,
+        bodyFont: {
+          family: 'Noto Sans'
+        },
+        bodyColor: '#E9E4EC',
+        titleFont: {
+          family: 'Noto Sans',
+          size: 14
+        },
+        callbacks: {
+          title(chart) {
+            return `${chart[0].label}. Total: $${formatNumber(
+              chart
+                .map(item => item.raw as number)
+                .reduce((item, a) => item + a, 0)
+            )}`;
+          },
+          label(chart) {
+            return `${chart.dataset.label}: $${formatNumber(
+              Number(chart.formattedValue)
+            )}`;
+          }
+        }
+      }
+    },
+    scales: {
+      x: {
+        display: true,
+        grid: {
+          lineWidth: 1.5,
+          color: '#F6F2FB'
+        },
+        ticks: {
+          color: '#635972',
+          font: {
+            family: 'Noto Sans'
+          }
+        }
+      },
+      y: {
+        display: true,
+        grid: {
+          lineWidth: 1.5,
+          color: '#F6F2FB'
+        },
+        ticks: {
+          color: '#635972',
+          font: {
+            family: 'Noto Sans'
+          },
+          callback(value) {
+            return `$${formatNumber(Number(value))}`;
+          }
+        }
+      }
+    }
+  };
+
+  function getDatasets(dataArray: CostExplorerDataProps[]) {
+    const dates = dataArray.map(item =>
+      dateFormatter(item.date, queryGranularity)
+    );
+
+    const datapoints = dataArray.map(
+      item => item.datapoints
+    ) as CostExplorerDatapointsProps[][];
+
+    const tempDataSets = new Map<string, any>();
+    for (let i = 0; i < datapoints.length; i += 1) {
+      for (let j = 0; j < datapoints[i].length; j += 1) {
+        if (!tempDataSets.has(datapoints[i][j].name)) {
+          tempDataSets.set(datapoints[i][j].name, []);
+        }
+      }
+    }
+
+    for (let i = 0; i < dataArray.length; i += 1) {
+      const newDatapoints = dataArray[i].datapoints;
+      const tempLabels: string[] = [];
+      newDatapoints.forEach(datapoint => {
+        const { name } = datapoint;
+        tempLabels.push(name);
+        const listOfAmounts = tempDataSets.get(name);
+        listOfAmounts.push(Number(datapoint.amount.toFixed(0)));
+        tempDataSets.set(name, listOfAmounts);
+      });
+
+      Array.from(tempDataSets.keys()).forEach(name => {
+        let found = false;
+        tempLabels.forEach(l => {
+          if (name === l) {
+            found = true;
+          }
+        });
+        if (!found) {
+          const listOfAmounts = tempDataSets.get(name);
+          listOfAmounts.push(null);
+          tempDataSets.set(name, listOfAmounts);
+        }
+      });
+    }
+
+    const datasets: {
+      label: string;
+      data: number[];
+      backgroundColor: string;
+      borderColor: string;
+      borderRadius: number;
+      barThickness: number;
+    }[] = [];
+
+    let index = 0;
+    tempDataSets.forEach((key, value) => {
+      datasets.push({
+        label: value,
+        data: key,
+        backgroundColor: colors[index],
+        borderColor: 'transparent',
+        borderRadius: 3,
+        barThickness: queryGranularity === 'monthly' ? 20 : 8
+      });
+      index += 1;
+    });
+
+    const newData: ChartData<'bar'> = {
+      labels: dates,
+      datasets
+    };
+
+    setChartData(newData);
+  }
+
+  function handleFilterChange(e: ChangeEvent<HTMLSelectElement>, type: string) {
+    if (type === 'group') {
+      setQueryGroup(e.currentTarget.value as CostExplorerQueryGroupProps);
+    }
+
+    if (type === 'granularity') {
+      setQueryGranularity(
+        e.currentTarget.value as CostExplorerQueryGranularityProps
+      );
+    }
+
+    if (type === 'date') {
+      setQueryDate(e.currentTarget.value as CostExplorerQueryDateProps);
+    }
+  }
+
+  useEffect(() => {
+    if (data) {
+      getDatasets(data);
+    }
+  }, [data]);
+
+  return {
+    chartData,
+    options,
+    groupBySelect,
+    granularitySelect,
+    dateSelect,
+    handleFilterChange
+  };
+}
+
+export default useCostExplorerChart;

--- a/dashboard/components/dashboard/components/cost-explorer/utils/dateHelper.ts
+++ b/dashboard/components/dashboard/components/cost-explorer/utils/dateHelper.ts
@@ -1,0 +1,92 @@
+const dateHelper = {
+  getToday() {
+    const date = new Date();
+    return date.toJSON().slice(0, 10);
+  },
+
+  getLastMonth() {
+    const date = new Date();
+    date.setDate(1);
+    date.setMonth(date.getMonth() - 1);
+    return date.toJSON().slice(0, 10);
+  },
+
+  getLastDayOfLastMonth() {
+    const date = new Date();
+    date.setDate(0);
+    date.setMonth(date.getMonth() + 1, 0);
+    return date.toJSON().slice(0, 10);
+  },
+
+  getLastThreeMonths() {
+    const date = new Date();
+    date.setDate(1);
+    date.setMonth(date.getMonth() - 3);
+    return date.toJSON().slice(0, 10);
+  },
+
+  getLastSixMonths() {
+    const date = new Date();
+    date.setDate(1);
+    date.setMonth(date.getMonth() - 6);
+    return date.toJSON().slice(0, 10);
+  },
+
+  getLastTwelveMonths() {
+    const date = new Date();
+    date.setMonth(date.getMonth() - 12);
+    return date.toJSON().slice(0, 10);
+  },
+
+  getMinDateStart() {
+    const date = new Date();
+    date.setFullYear(date.getFullYear() - 2);
+    return date.toJSON().slice(0, 10);
+  },
+
+  getMaxDateStart() {
+    return new Date();
+  }
+};
+
+export function dateFormatter(dateParam: string, granularity: string) {
+  const date = new Date(dateParam);
+  let formattedDate;
+
+  if (granularity === 'monthly') {
+    formattedDate = date.toLocaleDateString('en-US', {
+      timeZone: 'UTC',
+      year: 'numeric',
+      month: 'short'
+    });
+  }
+
+  if (granularity === 'daily') {
+    formattedDate = date.toLocaleDateString('en-US', {
+      timeZone: 'UTC',
+      year: 'numeric',
+      month: 'short',
+      day: '2-digit'
+    });
+  }
+  return formattedDate;
+}
+
+export const lastMonth = [
+  dateHelper.getLastMonth(),
+  dateHelper.getLastDayOfLastMonth()
+];
+export const lastThreeMonths = [
+  dateHelper.getLastThreeMonths(),
+  dateHelper.getLastDayOfLastMonth()
+];
+export const lastSixMonths = [
+  dateHelper.getLastSixMonths(),
+  dateHelper.getToday()
+];
+export const lastTwelveMonths = [
+  dateHelper.getLastTwelveMonths(),
+  dateHelper.getLastDayOfLastMonth()
+];
+
+export default dateHelper;

--- a/dashboard/components/dashboard/components/cost-explorer/utils/mockDataChart.ts
+++ b/dashboard/components/dashboard/components/cost-explorer/utils/mockDataChart.ts
@@ -1,0 +1,171 @@
+const dummyStats = {
+  regions: 17,
+  resources: 257,
+  users: 0,
+  cost: [
+    { date: '2023-01-05T21:09:56.176672794Z', amount: 74 },
+    { date: '2022-08-05T21:09:56.176673175Z', amount: 120 },
+    { date: '2022-09-05T21:09:56.176674426Z', amount: 140 },
+    { date: '2022-10-05T21:09:56.176674926Z', amount: 200 },
+    { date: '2022-11-05T21:09:56.176675116Z', amount: 60 },
+    { date: '2022-12-05T21:09:56.176675608Z', amount: 120 },
+    { date: '2023-01-05T21:09:56.176675756Z', amount: 20 }
+  ]
+};
+
+const dummyData = [
+  {
+    date: '2022-03',
+    datapoints: [
+      {
+        name: 'Amazon Elastic Load Balancer',
+        amount: 85.1
+      },
+      {
+        name: 'AWS Lambda',
+        amount: 45.1
+      },
+      {
+        name: 'Amazon API Gateway',
+        amount: 25.1
+      },
+      {
+        name: 'Amazon SQS',
+        amount: 75.1
+      },
+      {
+        name: 'Others',
+        amount: 15.1
+      }
+    ]
+  },
+  {
+    date: '2022-04',
+    datapoints: [
+      {
+        name: 'Amazon Elastic Load Balancer',
+        amount: 85.1
+      },
+      {
+        name: 'AWS Lambda',
+        amount: 35.1
+      },
+      {
+        name: 'Amazon API Gateway',
+        amount: 7.1
+      },
+      {
+        name: 'Amazon SQS',
+        amount: 25.1
+      },
+      {
+        name: 'Others',
+        amount: 65.1
+      }
+    ]
+  },
+  {
+    date: '2022-05',
+    datapoints: [
+      {
+        name: 'Amazon Elastic Load Balancer',
+        amount: 105.1
+      },
+      {
+        name: 'AWS Lambda',
+        amount: 40.1
+      },
+      {
+        name: 'Amazon API Gateway',
+        amount: 17.6
+      },
+      {
+        name: 'Amazon SQS',
+        amount: 25.1
+      },
+      {
+        name: 'Others',
+        amount: 65.1
+      }
+    ]
+  },
+  {
+    date: '2022-06',
+    datapoints: [
+      {
+        name: 'Amazon Elastic Load Balancer',
+        amount: 99.4
+      },
+      {
+        name: 'AWS Lambda',
+        amount: 40.1
+      },
+      {
+        name: 'Amazon API Gateway',
+        amount: 37.6
+      },
+      {
+        name: 'Amazon SQS',
+        amount: 25.1
+      },
+      {
+        name: 'Others',
+        amount: 65.1
+      }
+    ]
+  },
+  {
+    date: '2022-07',
+    datapoints: [
+      {
+        name: 'Amazon Elastic Load Balancer',
+        amount: 75.1
+      },
+      {
+        name: 'AWS Lambda',
+        amount: 54.1
+      },
+      {
+        name: 'Amazon API Gateway',
+        amount: 37.6
+      },
+      {
+        name: 'Amazon SQS',
+        amount: 5.1
+      },
+      {
+        name: 'Others',
+        amount: 109.1
+      }
+    ]
+  },
+  {
+    date: '2022-08',
+    datapoints: [
+      {
+        name: 'Amazon Elastic Load Balancer',
+        amount: 175.1
+      },
+      {
+        name: 'AWS Lambda',
+        amount: 84.1
+      },
+      {
+        name: 'Amazon API Gateway',
+        amount: 47.6
+      },
+      {
+        name: 'Amazon SQS',
+        amount: 15.1
+      },
+      {
+        name: 'Others',
+        amount: 39.1
+      }
+    ]
+  }
+];
+
+const mockDataChart = [dummyStats, dummyData];
+
+export default mockDataChart;

--- a/dashboard/components/dashboard/components/resources-manager/DashboardResourcesManager.tsx
+++ b/dashboard/components/dashboard/components/resources-manager/DashboardResourcesManager.tsx
@@ -4,13 +4,20 @@ import DashboardResourcesManagerSkeleton from './DashboardResourcesManagerSkelet
 import useResourcesManager from './hooks/useResourcesManager';
 
 function DashboardResourcesManager() {
-  const { loading, data, error, fetch } = useResourcesManager();
+  const { loading, data, error, fetch, query, setQuery } =
+    useResourcesManager();
 
   if (loading) return <DashboardResourcesManagerSkeleton />;
 
   if (error) return <DashboardResourcesManagerError fetch={fetch} />;
 
-  return <DashboardResourcesManagerChart data={data} />;
+  return (
+    <DashboardResourcesManagerChart
+      data={data}
+      query={query}
+      setQuery={setQuery}
+    />
+  );
 }
 
 export default DashboardResourcesManager;

--- a/dashboard/components/dashboard/components/resources-manager/DashboardResourcesManagerCard.tsx
+++ b/dashboard/components/dashboard/components/resources-manager/DashboardResourcesManagerCard.tsx
@@ -1,21 +1,29 @@
-import React from 'react';
+import React, { Dispatch, SetStateAction } from 'react';
 import { Doughnut } from 'react-chartjs-2';
 import { Chart as ChartJS, ArcElement, Tooltip, Legend } from 'chart.js';
 import Select from '../select/Select';
-import { ResourcesManagerData } from './hooks/useResourcesManager';
+import {
+  ResourcesManagerData,
+  ResourcesManagerQuery
+} from './hooks/useResourcesManager';
 import useResourcesManagerChart from './hooks/useResourcesManagerChart';
 
 ChartJS.register(ArcElement, Tooltip, Legend);
 
 type DashboardResourcesManagerCardProps = {
   data: ResourcesManagerData | undefined;
+  query: ResourcesManagerQuery;
+  setQuery: Dispatch<SetStateAction<ResourcesManagerQuery>>;
 };
 
 function DashboardResourcesManagerCard({
-  data
+  data,
+  query,
+  setQuery
 }: DashboardResourcesManagerCardProps) {
-  const { chartData, options, select, query, handleChange } =
-    useResourcesManagerChart({ data });
+  const { chartData, options, select, handleChange } = useResourcesManagerChart(
+    { data, setQuery }
+  );
 
   return (
     <div className="w-full rounded-lg bg-white py-4 px-6 pb-6">

--- a/dashboard/components/dashboard/components/resources-manager/DashboardResourcesManagerError.tsx
+++ b/dashboard/components/dashboard/components/resources-manager/DashboardResourcesManagerError.tsx
@@ -14,7 +14,7 @@ function DashboardResourcesManagerError({
           There was an error loading the resources manager.
         </p>
         <div className="flex-shrink-0">
-          <Button style="outline" size="sm" onClick={fetch}>
+          <Button style="outline" size="sm" onClick={() => fetch()}>
             <svg
               xmlns="http://www.w3.org/2000/svg"
               width="16"

--- a/dashboard/components/dashboard/components/resources-manager/hooks/useResourcesManager.tsx
+++ b/dashboard/components/dashboard/components/resources-manager/hooks/useResourcesManager.tsx
@@ -6,12 +6,25 @@ export type ResourcesManagerData = {
   amount: number;
 }[];
 
+export type ResourcesManagerQuery =
+  | 'provider'
+  | 'service'
+  | 'region'
+  | 'account'
+  | 'view';
+
+export type ResourcesManagerGroupBySelectProps = {
+  values: ResourcesManagerQuery[];
+  displayValues: string[];
+};
+
 function useResourcesManager() {
   const [loading, setLoading] = useState(true);
   const [data, setData] = useState<ResourcesManagerData>();
   const [error, setError] = useState(false);
+  const [query, setQuery] = useState<ResourcesManagerQuery>('provider');
 
-  function fetch() {
+  function fetch(newQuery: ResourcesManagerQuery = 'provider') {
     if (!loading) {
       setLoading(true);
     }
@@ -27,10 +40,10 @@ function useResourcesManager() {
   }
 
   useEffect(() => {
-    fetch();
-  }, []);
+    fetch(query);
+  }, [query]);
 
-  return { loading, data, error, fetch };
+  return { loading, data, error, fetch, query, setQuery };
 }
 
 export default useResourcesManager;

--- a/dashboard/components/dashboard/components/resources-manager/hooks/useResourcesManager.tsx
+++ b/dashboard/components/dashboard/components/resources-manager/hooks/useResourcesManager.tsx
@@ -1,9 +1,9 @@
 import { useEffect, useState } from 'react';
-import mockDataForDashboard from '../../../utils/mockDataForDashboard';
+import settingsService from '../../../../../services/settingsService';
 
 export type ResourcesManagerData = {
-  name: string;
-  amount: number;
+  label: string;
+  total: number;
 }[];
 
 export type ResourcesManagerQuery =
@@ -24,7 +24,7 @@ function useResourcesManager() {
   const [error, setError] = useState(false);
   const [query, setQuery] = useState<ResourcesManagerQuery>('provider');
 
-  function fetch(newQuery: ResourcesManagerQuery = 'provider') {
+  function fetch(newQuery: ResourcesManagerQuery = 'region') {
     if (!loading) {
       setLoading(true);
     }
@@ -33,10 +33,18 @@ function useResourcesManager() {
       setError(false);
     }
 
-    setTimeout(() => {
-      setData(mockDataForDashboard.resources);
-      setLoading(false);
-    }, 1500);
+    const payload = { filter: newQuery, exclude: [] };
+    const payloadJson = JSON.stringify(payload);
+
+    settingsService.getGlobalResources(payloadJson).then(res => {
+      if (res === Error) {
+        setLoading(false);
+        setError(true);
+      } else {
+        setLoading(false);
+        setData(res);
+      }
+    });
   }
 
   useEffect(() => {

--- a/dashboard/components/dashboard/components/resources-manager/hooks/useResourcesManagerChart.tsx
+++ b/dashboard/components/dashboard/components/resources-manager/hooks/useResourcesManagerChart.tsx
@@ -1,37 +1,31 @@
 import { ChartData, ChartOptions } from 'chart.js';
-import { ChangeEvent, useState } from 'react';
+import { ChangeEvent, Dispatch, SetStateAction } from 'react';
 import formatNumber from '../../../../../utils/formatNumber';
-import { ResourcesManagerData } from './useResourcesManager';
+import {
+  ResourcesManagerData,
+  ResourcesManagerGroupBySelectProps,
+  ResourcesManagerQuery
+} from './useResourcesManager';
 
 export type ResourcesManagerChartProps = {
   name: string;
   amount: number;
 };
 
-type ResourcesManagerChartQuery =
-  | 'provider'
-  | 'service'
-  | 'region'
-  | 'account'
-  | 'view';
-
-type GroupBySelectProps = {
-  values: ResourcesManagerChartQuery[];
-  displayValues: string[];
-};
-
 type useResourcesManagerChartProps = {
   data: ResourcesManagerData | undefined;
+  setQuery: Dispatch<SetStateAction<ResourcesManagerQuery>>;
 };
 
-function useResourcesManagerChart({ data }: useResourcesManagerChartProps) {
-  const [query, setQuery] = useState<ResourcesManagerChartQuery>('provider');
-
+function useResourcesManagerChart({
+  data,
+  setQuery
+}: useResourcesManagerChartProps) {
   function handleChange(e: ChangeEvent<HTMLSelectElement>) {
-    setQuery(e.currentTarget.value as ResourcesManagerChartQuery);
+    setQuery(e.currentTarget.value as ResourcesManagerQuery);
   }
 
-  const select: GroupBySelectProps = {
+  const select: ResourcesManagerGroupBySelectProps = {
     values: ['provider', 'service', 'region', 'account', 'view'],
     displayValues: [
       'Cloud provider',
@@ -116,7 +110,7 @@ function useResourcesManagerChart({ data }: useResourcesManagerChartProps) {
     }
   };
 
-  return { chartData, options, select, query, handleChange };
+  return { chartData, options, select, handleChange };
 }
 
 export default useResourcesManagerChart;

--- a/dashboard/components/dashboard/components/resources-manager/hooks/useResourcesManagerChart.tsx
+++ b/dashboard/components/dashboard/components/resources-manager/hooks/useResourcesManagerChart.tsx
@@ -25,7 +25,8 @@ function useResourcesManagerChart({
     setQuery(e.currentTarget.value as ResourcesManagerQuery);
   }
 
-  const select: ResourcesManagerGroupBySelectProps = {
+  /* To be un-commented when 'view' is supported 
+    const select: ResourcesManagerGroupBySelectProps = {
     values: ['provider', 'service', 'region', 'account', 'view'],
     displayValues: [
       'Cloud provider',
@@ -33,6 +34,16 @@ function useResourcesManagerChart({
       'Cloud region',
       'Cloud account',
       'Custom views'
+    ]
+  }; */
+
+  const select: ResourcesManagerGroupBySelectProps = {
+    values: ['provider', 'service', 'region', 'account'],
+    displayValues: [
+      'Cloud provider',
+      'Cloud service',
+      'Cloud region',
+      'Cloud account'
     ]
   };
 

--- a/dashboard/components/dashboard/components/resources-manager/hooks/useResourcesManagerChart.tsx
+++ b/dashboard/components/dashboard/components/resources-manager/hooks/useResourcesManagerChart.tsx
@@ -8,8 +8,8 @@ import {
 } from './useResourcesManager';
 
 export type ResourcesManagerChartProps = {
-  name: string;
-  amount: number;
+  label: string;
+  total: number;
 };
 
 type useResourcesManagerChartProps = {
@@ -40,15 +40,15 @@ function useResourcesManagerChart({
 
   const sortByDescendingCosts = data?.sort(
     (a: ResourcesManagerChartProps, b: ResourcesManagerChartProps) =>
-      b.amount - a.amount
+      b.total - a.total
   );
 
   const chartData: ChartData<'doughnut'> = {
-    labels: sortByDescendingCosts?.map(item => item.name),
+    labels: sortByDescendingCosts?.map(item => item.label),
     datasets: [
       {
         data: sortByDescendingCosts?.map(item =>
-          Number(formatNumber(item.amount))
+          Number(formatNumber(item.total))
         ) as number[],
         backgroundColor: colors,
         borderColor: '#FFFFFF',

--- a/dashboard/components/dashboard/components/top-stats/DashboardTopStatsCards.tsx
+++ b/dashboard/components/dashboard/components/top-stats/DashboardTopStatsCards.tsx
@@ -11,7 +11,7 @@ function DashboardTopStatsCards({ data }: DashboardTopStatsCardsProps) {
       {data && (
         <div className="grid-col grid gap-8 md:grid-cols-2 lg:grid-cols-4">
           <Card
-            label="Cloud accounts"
+            label={data.accounts === 1 ? 'Cloud account' : 'Cloud accounts'}
             value={data.accounts}
             tooltip="Number of connected cloud accounts"
             icon={
@@ -49,7 +49,7 @@ function DashboardTopStatsCards({ data }: DashboardTopStatsCardsProps) {
             }
           />
           <Card
-            label="Regions"
+            label={data.regions === 1 ? 'Region' : 'Regions'}
             value={data.regions}
             tooltip="Number of regions where a cloud service is running across connected cloud accounts"
             icon={
@@ -86,7 +86,7 @@ function DashboardTopStatsCards({ data }: DashboardTopStatsCardsProps) {
             }
           />
           <Card
-            label="Resources"
+            label={data.resources === 1 ? 'Resource' : 'Resources'}
             value={data.resources}
             tooltip="Number of cloud resources across cloud accounts"
             icon={

--- a/dashboard/components/dashboard/utils/mockDataForDashboard.ts
+++ b/dashboard/components/dashboard/utils/mockDataForDashboard.ts
@@ -163,10 +163,10 @@ const regions = [
 ];
 
 const resources = [
-  { name: 'AWS', amount: 451 },
-  { name: 'Azure', amount: 153 },
-  { name: 'GCP', amount: 259 },
-  { name: 'OVH', amount: 100 }
+  { label: 'AWS', total: 451 },
+  { label: 'Azure', total: 153 },
+  { label: 'GCP', total: 259 },
+  { label: 'OVH', total: 100 }
 ];
 
 const costs = [

--- a/dashboard/components/dashboard/utils/mockDataForDashboard.ts
+++ b/dashboard/components/dashboard/utils/mockDataForDashboard.ts
@@ -169,7 +169,7 @@ const resources = [
   { name: 'OVH', amount: 100 }
 ];
 
-const explorer = [
+const costs = [
   {
     date: '2022-03',
     datapoints: [
@@ -322,6 +322,6 @@ const explorer = [
   }
 ];
 
-const mockDataForDashboard = { stats, regions, resources, explorer };
+const mockDataForDashboard = { stats, regions, resources, costs };
 
 export default mockDataForDashboard;

--- a/dashboard/components/layout/Layout.tsx
+++ b/dashboard/components/layout/Layout.tsx
@@ -38,7 +38,7 @@ function Layout({ children }: LayoutProps) {
           displayBanner
             ? 'mt-[145px] min-h-[calc(100vh-145px)]'
             : 'mt-[73px] min-h-[calc(100vh-73px)]'
-        } bg-black-100 p-6 xl:px-8 2xl:px-24`}
+        } bg-black-100 p-6 pb-12 xl:px-8 2xl:px-24`}
       >
         {canRender && children}
 

--- a/dashboard/components/layout/hooks/useGlobalStats.tsx
+++ b/dashboard/components/layout/hooks/useGlobalStats.tsx
@@ -25,6 +25,7 @@ function useGlobalStats() {
 
     settingsService.getGlobalStats().then(res => {
       if (res === Error) {
+        setLoading(false);
         setError(true);
       } else {
         setLoading(false);

--- a/dashboard/pages/dashboard.tsx
+++ b/dashboard/pages/dashboard.tsx
@@ -20,7 +20,7 @@ function Dashboard() {
           <DashboardCloudMap />
           <DashboardResourcesManager />
         </Grid>
-        <DashboardCostExplorer />
+        {/* to be un-commented on next release <DashboardCostExplorer /> */}
       </DashboardLayout>
     </>
   );

--- a/dashboard/pages/dashboard.tsx
+++ b/dashboard/pages/dashboard.tsx
@@ -1,5 +1,6 @@
 import Head from 'next/head';
 import DashboardCloudMap from '../components/dashboard/components/cloud-map/DashboardCloudMap';
+import DashboardCostExplorer from '../components/dashboard/components/cost-explorer/DashboardCostExplorer';
 import DashboardLayout from '../components/dashboard/components/DashboardLayout';
 import DashboardResourcesManager from '../components/dashboard/components/resources-manager/DashboardResourcesManager';
 import DashboardTopStats from '../components/dashboard/components/top-stats/DashboardTopStats';
@@ -19,6 +20,7 @@ function Dashboard() {
           <DashboardCloudMap />
           <DashboardResourcesManager />
         </Grid>
+        <DashboardCostExplorer />
       </DashboardLayout>
     </>
   );

--- a/dashboard/services/settingsService.ts
+++ b/dashboard/services/settingsService.ts
@@ -62,6 +62,29 @@ const settingsService = {
     }
   },
 
+  async getGlobalLocations() {
+    try {
+      const res = await fetch(`${BASE_URL}/global/locations`, settings('GET'));
+      const data = await res.json();
+      return data;
+    } catch (error) {
+      return Error;
+    }
+  },
+
+  async getGlobalResources(payload: string) {
+    try {
+      const res = await fetch(
+        `${BASE_URL}/global/resources`,
+        settings('POST', payload)
+      );
+      const data = await res.json();
+      return data;
+    } catch (error) {
+      return Error;
+    }
+  },
+
   async getInventoryStats() {
     try {
       const res = await fetch(`${BASE_URL}/stats`, settings('GET'));


### PR DESCRIPTION
### Description
- Added cost explorer widget to the dashboard (will remain hidden until next release)
- Plugged the API for Cloud map widget & Resources manager widget

### Screenshots
`Cost explorer loading`
<img width="1411" alt="image" src="https://user-images.githubusercontent.com/13384559/219662852-21d13688-e4a2-48d6-a172-30df0746110e.png">

`Cost explorer error`
<img width="1411" alt="image" src="https://user-images.githubusercontent.com/13384559/219662989-d28e5ea4-10ae-4775-9bda-93fe826b51d3.png">

`Cost explorer success`
<img width="1411" alt="image" src="https://user-images.githubusercontent.com/13384559/219662738-b45a0570-1c25-48f1-a4b3-d7a5f05bdeca.png">

