### PR TITLE
Komiser minor improvements

### DIFF
--- a/dashboard/components/dashboard/components/cloud-map/DashboardCloudMapCard.tsx
+++ b/dashboard/components/dashboard/components/cloud-map/DashboardCloudMapCard.tsx
@@ -1,6 +1,8 @@
+import Button from '../../../button/Button';
 import DashboardCloudMapChart from './DashboardCloudMapChart';
 import DashboardCloudMapTooltip from './DashboardCloudMapTooltip';
 import { DashboardCloudMapRegions } from './hooks/useCloudMap';
+import useCloudMapExpand from './hooks/useCloudMapExpand';
 import useCloudMapTooltip from './hooks/useCloudMapTooltip';
 
 type DashboardCloudMapCardProps = {
@@ -8,9 +10,14 @@ type DashboardCloudMapCardProps = {
 };
 function DashboardCloudMapCard({ data }: DashboardCloudMapCardProps) {
   const { tooltip, setTooltip } = useCloudMapTooltip();
+  const { isOpen, toggle } = useCloudMapExpand();
 
   return (
-    <div className="w-full rounded-lg bg-white py-4 px-6 pb-6">
+    <div
+      className={`${
+        isOpen ? 'fixed inset-0 z-30' : ''
+      } w-full rounded-lg bg-white py-4 px-6 pb-6`}
+    >
       <div className="-mx-6 flex items-center justify-between border-b border-black-200/40 px-6 pb-4">
         <div>
           <p className="text-sm font-semibold text-black-900">Cloud map</p>
@@ -19,7 +26,25 @@ function DashboardCloudMapCard({ data }: DashboardCloudMapCardProps) {
             Analyze which regions have active resources
           </p>
         </div>
-        <div className="h-[60px]"></div>
+        <div className="flex h-[60px] items-center">
+          <Button style="ghost" size="sm" onClick={toggle}>
+            <svg
+              xmlns="http://www.w3.org/2000/svg"
+              width="20"
+              height="20"
+              fill="none"
+              viewBox="0 0 24 24"
+            >
+              <path
+                stroke="currentColor"
+                strokeLinecap="round"
+                strokeLinejoin="round"
+                strokeWidth="1.5"
+                d="M21 9V3h-6M3 15v6h6M21 3l-7.5 7.5M10.5 13.5L3 21"
+              ></path>
+            </svg>
+          </Button>
+        </div>
       </div>
       <div className="mt-8"></div>
       <DashboardCloudMapChart regions={data} setTooltip={setTooltip} />

--- a/dashboard/components/dashboard/components/cloud-map/DashboardCloudMapCard.tsx
+++ b/dashboard/components/dashboard/components/cloud-map/DashboardCloudMapCard.tsx
@@ -15,7 +15,7 @@ function DashboardCloudMapCard({ data }: DashboardCloudMapCardProps) {
   return (
     <div
       className={`${
-        isOpen ? 'fixed inset-0 z-30' : ''
+        isOpen ? 'fixed inset-0 z-30 origin-left animate-scale' : ''
       } w-full rounded-lg bg-white py-4 px-6 pb-6`}
     >
       <div className="-mx-6 flex items-center justify-between border-b border-black-200/40 px-6 pb-4">

--- a/dashboard/components/dashboard/components/cloud-map/hooks/useCloudMapExpand.tsx
+++ b/dashboard/components/dashboard/components/cloud-map/hooks/useCloudMapExpand.tsx
@@ -1,0 +1,31 @@
+import { useEffect, useState } from 'react';
+
+function useCloudMapExpand() {
+  const [isOpen, setIsOpen] = useState(false);
+
+  function toggle() {
+    setIsOpen(!isOpen);
+  }
+
+  function close() {
+    setIsOpen(false);
+  }
+
+  useEffect(() => {
+    function escFunction(event: KeyboardEvent) {
+      if (event.key === 'Escape') {
+        close();
+      }
+    }
+
+    document.addEventListener('keydown', escFunction, false);
+
+    return () => {
+      document.removeEventListener('keydown', escFunction, false);
+    };
+  }, []);
+
+  return { isOpen, toggle };
+}
+
+export default useCloudMapExpand;

--- a/dashboard/components/inventory/components/InventoryLayout.tsx
+++ b/dashboard/components/inventory/components/InventoryLayout.tsx
@@ -55,7 +55,6 @@ function InventoryLayout({
         >
           <button
             onClick={() => {
-              if (!router.query.view) return;
               router.push(router.pathname);
             }}
             className={`flex items-center gap-3 rounded-lg px-4 py-3 text-left text-sm font-medium

--- a/dashboard/components/navbar/Navbar.tsx
+++ b/dashboard/components/navbar/Navbar.tsx
@@ -18,12 +18,14 @@ function Navbar() {
       } z-30 flex w-full items-center justify-between gap-10 border-b border-black-200/30 bg-white py-4 px-6 xl:pr-8 2xl:pr-24`}
     >
       <div className="flex items-center gap-8 text-sm font-semibold text-black-400">
-        <Image
-          src="./assets/img/komiser.svg"
-          width={40}
-          height={40}
-          alt="Komiser logo"
-        />
+        <Link href="/dashboard">
+          <Image
+            src="./assets/img/komiser.svg"
+            width={40}
+            height={40}
+            alt="Komiser logo"
+          />
+        </Link>
         {nav.map((navItem, idx) => (
           <Link
             key={idx}

--- a/dashboard/tailwind.config.js
+++ b/dashboard/tailwind.config.js
@@ -140,6 +140,19 @@ module.exports = {
             transform: 'scale(2.25, 2.25)',
             opacity: 0
           }
+        },
+        scale: {
+          '0%': {
+            transform: 'scale(0.97)',
+            opacity: 0.85
+          },
+          '50%': {
+            transform: 'scale(1.005)'
+          },
+          '100%': {
+            transform: 'scale(1)',
+            opacity: 1
+          }
         }
       },
       animation: {
@@ -150,7 +163,8 @@ module.exports = {
         'fade-in-down-short': 'fade-in-down-short 250ms ease forwards',
         'fade-in-left': 'fade-in-left 250ms ease forwards',
         'width-to-fit': 'width-to-fit 5000ms ease-in forwards',
-        'wide-pulse': 'wide-pulse 2000ms ease-in infinite'
+        'wide-pulse': 'wide-pulse 2000ms ease-in infinite',
+        scale: 'scale 250ms ease forwards'
       }
     }
   },


### PR DESCRIPTION
## Changes Made

- `Navbar`: added a link to the Komiser logo in the navbar pointing to `/dashboard`
- `Inventory`:  when `All Resources` is clicked from the sidebar, the page will reload and existing filters will be reset.
- `Dashboard`:  added an expand button to the cloud map widget. When clicked, the cloud map will take 100% of the screen width and height.

## Screenshots
`Expand cloud map`

<img width="1410" alt="image" src="https://user-images.githubusercontent.com/13384559/220144489-0b443656-b727-4da4-beb8-243d6cdb2421.png">
<img width="1410" alt="image" src="https://user-images.githubusercontent.com/13384559/220144620-ee0daaaf-c2d0-4c2f-bc99-594465ca254f.png">

