### PR TITLE
fix: cost explorer fetch

### DIFF
--- a/dashboard/components/dashboard/components/cost-explorer/hooks/useCostExplorerChart.tsx
+++ b/dashboard/components/dashboard/components/cost-explorer/hooks/useCostExplorerChart.tsx
@@ -294,7 +294,7 @@ function useCostExplorerChart({
   }
 
   useEffect(() => {
-    if (data) {
+    if (data && data.length > 0) {
       getDatasets(data);
     }
   }, [data]);


### PR DESCRIPTION
- Hot fix to prevent `getDatasets` (cost explorer widget) from running if the data is empty.
