### PR TITLE
Fix/8 incorrect aws cost estimations due to BeginningOfMonth method

### DIFF
--- a/providers/aws/apigateway/apis.go
+++ b/providers/aws/apigateway/apis.go
@@ -13,11 +13,8 @@ import (
 	"github.com/aws/aws-sdk-go-v2/service/cloudwatch/types"
 	. "github.com/tailwarden/komiser/models"
 	. "github.com/tailwarden/komiser/providers"
+	"github.com/tailwarden/komiser/utils"
 )
-
-func BeginningOfMonth(date time.Time) time.Time {
-	return date.AddDate(0, 0, -date.Day()+1)
-}
 
 func Apis(ctx context.Context, client ProviderClient) ([]Resource, error) {
 	resources := make([]Resource, 0)
@@ -40,7 +37,7 @@ func Apis(ctx context.Context, client ProviderClient) ([]Resource, error) {
 		}
 
 		metricsCountOutput, err := cloudwatchClient.GetMetricStatistics(ctx, &cloudwatch.GetMetricStatisticsInput{
-			StartTime:  aws.Time(BeginningOfMonth(time.Now())),
+			StartTime:  aws.Time(utils.BeginningOfMonth(time.Now())),
 			EndTime:    aws.Time(time.Now()),
 			MetricName: aws.String("Count"),
 			Namespace:  aws.String("AWS/ApiGateway"),

--- a/providers/aws/cloudfront/distributions.go
+++ b/providers/aws/cloudfront/distributions.go
@@ -13,11 +13,8 @@ import (
 	"github.com/aws/aws-sdk-go-v2/service/cloudwatch/types"
 	. "github.com/tailwarden/komiser/models"
 	. "github.com/tailwarden/komiser/providers"
+	"github.com/tailwarden/komiser/utils"
 )
-
-func BeginningOfMonth(date time.Time) time.Time {
-	return date.AddDate(0, 0, -date.Day()+1)
-}
 
 func Distributions(ctx context.Context, client ProviderClient) ([]Resource, error) {
 	resources := make([]Resource, 0)
@@ -37,7 +34,7 @@ func Distributions(ctx context.Context, client ProviderClient) ([]Resource, erro
 
 		for _, distribution := range output.DistributionList.Items {
 			metricsBytesDownloadedOutput, err := cloudwatchClient.GetMetricStatistics(ctx, &cloudwatch.GetMetricStatisticsInput{
-				StartTime:  aws.Time(BeginningOfMonth(time.Now())),
+				StartTime:  aws.Time(utils.BeginningOfMonth(time.Now())),
 				EndTime:    aws.Time(time.Now()),
 				MetricName: aws.String("BytesDownloaded"),
 				Namespace:  aws.String("AWS/CloudFront"),
@@ -63,7 +60,7 @@ func Distributions(ctx context.Context, client ProviderClient) ([]Resource, erro
 			}
 
 			metricsBytesUploadedOutput, err := cloudwatchClient.GetMetricStatistics(ctx, &cloudwatch.GetMetricStatisticsInput{
-				StartTime:  aws.Time(BeginningOfMonth(time.Now())),
+				StartTime:  aws.Time(utils.BeginningOfMonth(time.Now())),
 				EndTime:    aws.Time(time.Now()),
 				MetricName: aws.String("BytesUploaded"),
 				Namespace:  aws.String("AWS/CloudFront"),
@@ -89,7 +86,7 @@ func Distributions(ctx context.Context, client ProviderClient) ([]Resource, erro
 			}
 
 			metricsRequestsOutput, err := cloudwatchClient.GetMetricStatistics(ctx, &cloudwatch.GetMetricStatisticsInput{
-				StartTime:  aws.Time(BeginningOfMonth(time.Now())),
+				StartTime:  aws.Time(utils.BeginningOfMonth(time.Now())),
 				EndTime:    aws.Time(time.Now()),
 				MetricName: aws.String("Requests"),
 				Namespace:  aws.String("AWS/CloudFront"),

--- a/providers/aws/dynamodb/tables.go
+++ b/providers/aws/dynamodb/tables.go
@@ -13,10 +13,6 @@ import (
 	. "github.com/tailwarden/komiser/providers"
 )
 
-func BeginningOfMonth(date time.Time) time.Time {
-	return date.AddDate(0, 0, -date.Day()+1)
-}
-
 func Tables(ctx context.Context, client ProviderClient) ([]Resource, error) {
 	resources := make([]Resource, 0)
 	var config dynamodb.ListTablesInput

--- a/providers/aws/ec2/instances.go
+++ b/providers/aws/ec2/instances.go
@@ -16,6 +16,7 @@ import (
 	"github.com/aws/aws-sdk-go-v2/service/sts"
 	. "github.com/tailwarden/komiser/models"
 	. "github.com/tailwarden/komiser/providers"
+	"github.com/tailwarden/komiser/utils"
 )
 
 type Ec2Product struct {
@@ -71,10 +72,6 @@ func GetRegionName(code string) string {
 	return regions[code]
 }
 
-func BeginningOfMonth(date time.Time) time.Time {
-	return date.AddDate(0, 0, -date.Day()+1)
-}
-
 func Instances(ctx context.Context, client ProviderClient) ([]Resource, error) {
 	var nextToken string
 	resources := make([]Resource, 0)
@@ -116,7 +113,7 @@ func Instances(ctx context.Context, client ProviderClient) ([]Resource, error) {
 					})
 				}
 
-				startOfMonth := BeginningOfMonth(time.Now())
+				startOfMonth := utils.BeginningOfMonth(time.Now())
 				hourlyUsage := 0
 				if instance.LaunchTime.Before(startOfMonth) {
 					hourlyUsage = int(time.Now().Sub(startOfMonth).Hours())

--- a/providers/aws/eks/clusters.go
+++ b/providers/aws/eks/clusters.go
@@ -12,11 +12,8 @@ import (
 	"github.com/aws/aws-sdk-go-v2/service/sts"
 	. "github.com/tailwarden/komiser/models"
 	. "github.com/tailwarden/komiser/providers"
+	"github.com/tailwarden/komiser/utils"
 )
-
-func BeginningOfMonth(date time.Time) time.Time {
-	return date.AddDate(0, 0, -date.Day()+1)
-}
 
 func KubernetesClusters(ctx context.Context, client ProviderClient) ([]Resource, error) {
 	resources := make([]Resource, 0)
@@ -61,7 +58,7 @@ func KubernetesClusters(ctx context.Context, client ProviderClient) ([]Resource,
 			monthlyCost := 0.0
 			createdAt := time.Now()
 			if err == nil {
-				startOfMonth := BeginningOfMonth(time.Now())
+				startOfMonth := utils.BeginningOfMonth(time.Now())
 				hourlyUsage := 0
 				if (*outputDescribe.Cluster.CreatedAt).Before(startOfMonth) {
 					hourlyUsage = int(time.Now().Sub(startOfMonth).Hours())

--- a/providers/aws/elb/loadbalancers.go
+++ b/providers/aws/elb/loadbalancers.go
@@ -10,11 +10,8 @@ import (
 	"github.com/aws/aws-sdk-go-v2/service/elasticloadbalancingv2"
 	. "github.com/tailwarden/komiser/models"
 	. "github.com/tailwarden/komiser/providers"
+	"github.com/tailwarden/komiser/utils"
 )
-
-func BeginningOfMonth(date time.Time) time.Time {
-	return date.AddDate(0, 0, -date.Day()+1)
-}
 
 func LoadBalancers(ctx context.Context, client ProviderClient) ([]Resource, error) {
 	resources := make([]Resource, 0)
@@ -45,7 +42,7 @@ func LoadBalancers(ctx context.Context, client ProviderClient) ([]Resource, erro
 			}
 		}
 
-		startOfMonth := BeginningOfMonth(time.Now())
+		startOfMonth := utils.BeginningOfMonth(time.Now())
 		hourlyUsage := 0
 		if (*loadbalancer.CreatedTime).Before(startOfMonth) {
 			hourlyUsage = int(time.Since(startOfMonth).Hours())

--- a/providers/aws/lambda/functions.go
+++ b/providers/aws/lambda/functions.go
@@ -13,11 +13,8 @@ import (
 	"github.com/aws/aws-sdk-go-v2/service/lambda"
 	. "github.com/tailwarden/komiser/models"
 	. "github.com/tailwarden/komiser/providers"
+	"github.com/tailwarden/komiser/utils"
 )
-
-func BeginningOfMonth(date time.Time) time.Time {
-	return date.AddDate(0, 0, -date.Day()+1)
-}
 
 func Functions(ctx context.Context, client ProviderClient) ([]Resource, error) {
 	var config lambda.ListFunctionsInput
@@ -32,7 +29,7 @@ func Functions(ctx context.Context, client ProviderClient) ([]Resource, error) {
 
 		for _, o := range output.Functions {
 			metricsInvocationsOutput, err := cloudwatchClient.GetMetricStatistics(ctx, &cloudwatch.GetMetricStatisticsInput{
-				StartTime:  aws.Time(BeginningOfMonth(time.Now())),
+				StartTime:  aws.Time(utils.BeginningOfMonth(time.Now())),
 				EndTime:    aws.Time(time.Now()),
 				MetricName: aws.String("Invocations"),
 				Namespace:  aws.String("AWS/Lambda"),
@@ -58,7 +55,7 @@ func Functions(ctx context.Context, client ProviderClient) ([]Resource, error) {
 			}
 
 			metricsDurationOutput, err := cloudwatchClient.GetMetricStatistics(ctx, &cloudwatch.GetMetricStatisticsInput{
-				StartTime:  aws.Time(BeginningOfMonth(time.Now())),
+				StartTime:  aws.Time(utils.BeginningOfMonth(time.Now())),
 				EndTime:    aws.Time(time.Now()),
 				MetricName: aws.String("Duration"),
 				Namespace:  aws.String("AWS/Lambda"),

--- a/providers/aws/s3/buckets.go
+++ b/providers/aws/s3/buckets.go
@@ -13,11 +13,8 @@ import (
 	"github.com/aws/aws-sdk-go-v2/service/s3"
 	. "github.com/tailwarden/komiser/models"
 	. "github.com/tailwarden/komiser/providers"
+	"github.com/tailwarden/komiser/utils"
 )
-
-func BeginningOfMonth(date time.Time) time.Time {
-	return date.AddDate(0, 0, -date.Day()+1)
-}
 
 func ConvertBytesToTerabytes(bytes int64) float64 {
 	return float64(bytes) / 1000000000000
@@ -37,7 +34,7 @@ func Buckets(ctx context.Context, client ProviderClient) ([]Resource, error) {
 		for _, bucket := range output.Buckets {
 
 			metricsBucketSizebytesOutput, err := cloudwatchClient.GetMetricStatistics(ctx, &cloudwatch.GetMetricStatisticsInput{
-				StartTime:  aws.Time(BeginningOfMonth(time.Now())),
+				StartTime:  aws.Time(utils.BeginningOfMonth(time.Now())),
 				EndTime:    aws.Time(time.Now()),
 				MetricName: aws.String("BucketSizeBytes"),
 				Namespace:  aws.String("AWS/S3"),

--- a/providers/aws/sns/topics.go
+++ b/providers/aws/sns/topics.go
@@ -15,11 +15,8 @@ import (
 	"github.com/aws/aws-sdk-go-v2/service/sts"
 	. "github.com/tailwarden/komiser/models"
 	. "github.com/tailwarden/komiser/providers"
+	"github.com/tailwarden/komiser/utils"
 )
-
-func BeginningOfMonth(date time.Time) time.Time {
-	return date.AddDate(0, 0, -date.Day()+1)
-}
 
 func Topics(ctx context.Context, client ProviderClient) ([]Resource, error) {
 	resources := make([]Resource, 0)
@@ -62,7 +59,7 @@ func Topics(ctx context.Context, client ProviderClient) ([]Resource, error) {
 			topicName := strings.Replace(*topic.TopicArn, resourceArnPrefix, "", -1)
 
 			metricsMessagesPublishedOutput, err := cloudwatchClient.GetMetricStatistics(ctx, &cloudwatch.GetMetricStatisticsInput{
-				StartTime:  aws.Time(BeginningOfMonth(time.Now())),
+				StartTime:  aws.Time(utils.BeginningOfMonth(time.Now())),
 				EndTime:    aws.Time(time.Now()),
 				MetricName: aws.String("NumberOfMessagesPublished"),
 				Namespace:  aws.String("AWS/SNS"),

--- a/providers/aws/sqs/queues.go
+++ b/providers/aws/sqs/queues.go
@@ -14,11 +14,8 @@ import (
 	"github.com/aws/aws-sdk-go-v2/service/sqs"
 	. "github.com/tailwarden/komiser/models"
 	. "github.com/tailwarden/komiser/providers"
+	"github.com/tailwarden/komiser/utils"
 )
-
-func BeginningOfMonth(date time.Time) time.Time {
-	return date.AddDate(0, 0, -date.Day()+1)
-}
 
 func Queues(ctx context.Context, client ProviderClient) ([]Resource, error) {
 	resources := make([]Resource, 0)
@@ -37,7 +34,7 @@ func Queues(ctx context.Context, client ProviderClient) ([]Resource, error) {
 			queueName := path.Base(queue)
 
 			metricsNbOfMessagesSentOutput, err := cloudwatchClient.GetMetricStatistics(ctx, &cloudwatch.GetMetricStatisticsInput{
-				StartTime:  aws.Time(BeginningOfMonth(time.Now())),
+				StartTime:  aws.Time(utils.BeginningOfMonth(time.Now())),
 				EndTime:    aws.Time(time.Now()),
 				MetricName: aws.String("NumberOfMessagesSent"),
 				Namespace:  aws.String("AWS/SQS"),
@@ -63,7 +60,7 @@ func Queues(ctx context.Context, client ProviderClient) ([]Resource, error) {
 			}
 
 			metricsNbOfMessagesReceivedOutput, err := cloudwatchClient.GetMetricStatistics(ctx, &cloudwatch.GetMetricStatisticsInput{
-				StartTime:  aws.Time(BeginningOfMonth(time.Now())),
+				StartTime:  aws.Time(utils.BeginningOfMonth(time.Now())),
 				EndTime:    aws.Time(time.Now()),
 				MetricName: aws.String("NumberOfMessagesReceived"),
 				Namespace:  aws.String("AWS/SQS"),
@@ -89,7 +86,7 @@ func Queues(ctx context.Context, client ProviderClient) ([]Resource, error) {
 			}
 
 			metricsNbOfMessagesDeletedOutput, err := cloudwatchClient.GetMetricStatistics(ctx, &cloudwatch.GetMetricStatisticsInput{
-				StartTime:  aws.Time(BeginningOfMonth(time.Now())),
+				StartTime:  aws.Time(utils.BeginningOfMonth(time.Now())),
 				EndTime:    aws.Time(time.Now()),
 				MetricName: aws.String("NumberOfMessagesDeleted"),
 				Namespace:  aws.String("AWS/SQS"),

--- a/utils/datecalc.go
+++ b/utils/datecalc.go
@@ -1,0 +1,7 @@
+package utils
+
+import "time"
+
+func BeginningOfMonth(date time.Time) (time.Time, error) {
+	return time.Parse("2006-01-02", date.AddDate(0, 0, -date.Day()+1).Format("2006-01-02"))
+}

--- a/utils/datecalc.go
+++ b/utils/datecalc.go
@@ -2,6 +2,10 @@ package utils
 
 import "time"
 
-func BeginningOfMonth(date time.Time) (time.Time, error) {
-	return time.Parse("2006-01-02", date.AddDate(0, 0, -date.Day()+1).Format("2006-01-02"))
+func BeginningOfMonth(date time.Time) time.Time {
+	beginningOfMonth, err := time.Parse("2006-01-02", date.AddDate(0, 0, -date.Day()+1).Format("2006-01-02"))
+	if err != nil {
+		return time.Now()
+	}
+	return beginningOfMonth
 }


### PR DESCRIPTION
## Problem

In order to estimate the cost of some AWS resources, we utilize the custom made method `BeginningOfMonth`. This method took into account the timestamp when the resources were fetched, thus provided incorrect cost estimations.

## Solution

Refactored the method in order to provide only the date in `YYYY-MM-DD` format.

## Changes Made

- Refactored `BeginningOfMonth` method.
- Moved it to `utils` directory and imported it as a package where needed instead of declaring it every time.

## Additional Notes

In case of an error in the process of getting the date, the method returns the `time.NOW()` so the cost is estimated as `0`.

## Checklist

- [x] Code follows the <a href="https://github.com/tailwarden/komiser/blob/master/CONTRIBUTING.md">contributing</a> guidelines
- [x] Changes have been thoroughly tested
- [x] <a href="https://github.com/tailwarden/docs.komiser.io">Documentation</a> has been updated, if necessary
- [x] Any dependencies have been added to the project, if necessary

## Reviewers

@mlabouardy 

