### PR TITLE
Add /telemetry endpoint

### DIFF
--- a/handlers/resources_handler.go
+++ b/handlers/resources_handler.go
@@ -15,18 +15,18 @@ import (
 )
 
 type ApiHandler struct {
-	db         *bun.DB
-	ctx        context.Context
-	noTracking bool
-	cfg        models.Config
+	db               *bun.DB
+	ctx              context.Context
+	telemetryEnabled bool
+	cfg              models.Config
 }
 
-func NewApiHandler(ctx context.Context, noTracking bool, db *bun.DB, cfg models.Config) *ApiHandler {
+func NewApiHandler(ctx context.Context, telemetryEnabled bool, db *bun.DB, cfg models.Config) *ApiHandler {
 	handler := ApiHandler{
-		db:         db,
-		ctx:        ctx,
-		noTracking: noTracking,
-		cfg:        cfg,
+		db:               db,
+		ctx:              ctx,
+		telemetryEnabled: telemetryEnabled,
+		cfg:              cfg,
 	}
 	return &handler
 }

--- a/handlers/telemetry_handler.go
+++ b/handlers/telemetry_handler.go
@@ -1,0 +1,13 @@
+package handlers
+
+import "net/http"
+
+func (handler *ApiHandler) TelemetryHandler(w http.ResponseWriter, r *http.Request) {
+	response := struct {
+		TelemetryEnabled bool `json:"telemetry_enabled"`
+	}{
+		TelemetryEnabled: handler.telemetryEnabled,
+	}
+
+	respondWithJSON(w, 200, response)
+}

--- a/internal/api/v1/endpoints.go
+++ b/internal/api/v1/endpoints.go
@@ -44,6 +44,8 @@ func Endpoints(ctx context.Context, telemetry bool, db *bun.DB, cfg models.Confi
 	r.HandleFunc("/alerts/{id}", api.UpdateAlertHandler).Methods("PUT")
 	r.HandleFunc("/alerts/{id}", api.DeleteAlertHandler).Methods("DELETE")
 
+	r.HandleFunc("/telemetry", api.TelemetryHandler).Methods("GET")
+
 	r.PathPrefix("/").Handler(http.FileServer(assetFS()))
 
 	return r


### PR DESCRIPTION
This PR adds a very simple `GET /telementry` endpoint, which returns a json response with

```
{
    telemetry_enabled: true|false
}
```

that serves as the basis for collecting analytics in the frontend.

