### PR TITLE
Send weekly reporting (tags coverage and cost breakdown) on Friday

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -48,6 +48,7 @@ require (
 	github.com/segmentio/analytics-go v3.1.0+incompatible
 	github.com/sirupsen/logrus v1.9.0
 	github.com/siruspen/logrus v1.7.1
+	github.com/slack-go/slack v0.12.1
 	github.com/spf13/cobra v1.6.1
 	github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/common v1.0.582
 	github.com/tencentcloud/tencentcloud-sdk-go/tencentcloud/cvm v1.0.582
@@ -117,7 +118,6 @@ require (
 	github.com/robfig/cron/v3 v3.0.1 // indirect
 	github.com/rogpeppe/go-internal v1.8.0 // indirect
 	github.com/segmentio/backo-go v1.0.1 // indirect
-	github.com/slack-go/slack v0.12.1 // indirect
 	github.com/spf13/pflag v1.0.5 // indirect
 	github.com/tmthrgd/go-hex v0.0.0-20190904060850-447a3041c3bc // indirect
 	github.com/vmihailenco/msgpack/v5 v5.3.5 // indirect

--- a/go.sum
+++ b/go.sum
@@ -156,6 +156,7 @@ github.com/go-openapi/swag v0.19.14/go.mod h1:QYRuS/SOXUCsnplDa677K7+DxSOj6IPNl/
 github.com/go-resty/resty/v2 v2.7.0 h1:me+K9p3uhSmXtrBZ4k9jcEAfJmuC8IivWHwaLZwPrFY=
 github.com/go-resty/resty/v2 v2.7.0/go.mod h1:9PWDzw47qPphMRFfhsyk0NnSgvluHcljSMVIq3w7q0I=
 github.com/go-task/slim-sprig v0.0.0-20210107165309-348f09dbbbc0/go.mod h1:fyg7847qk6SyHyPtNmDHnmrv/HOrqktSC+C9fM+CJOE=
+github.com/go-test/deep v1.0.4 h1:u2CU3YKy9I2pmu9pX0eq50wCgjfGIt539SqR7FbHiho=
 github.com/go-test/deep v1.0.4/go.mod h1:wGDj63lr65AM2AQyKZd/NYHGb0R+1RLqB8NKt3aSFNA=
 github.com/gogo/protobuf v1.3.2 h1:Ov1cvc58UF3b5XjBnZv7+opcTcQFZebYjWzi34vdm4Q=
 github.com/gogo/protobuf v1.3.2/go.mod h1:P1XiOD3dCwIKUDQYPy72D8LYyHL2YPYrpS2s69NZV8Q=

--- a/models/config.go
+++ b/models/config.go
@@ -80,5 +80,6 @@ type TencentConfig struct {
 }
 
 type SlackConfig struct {
-	Webhook string `toml:"webhook"`
+	Webhook   string `toml:"webhook"`
+	Reporting bool   `toml:"reporting"`
 }

--- a/models/stat.go
+++ b/models/stat.go
@@ -49,3 +49,8 @@ type ViewStat struct {
 	Resources int     `json:"resources"`
 	Costs     float64 `json:"costs"`
 }
+
+type OutputCostByField struct {
+	Label string  `bun:"label"`
+	Total float64 `bun:"total"`
+}


### PR DESCRIPTION
## Problem

Currently, developers can set up alerts to track the cost and usage of their infrastructure. However, those alerts are triggered when certain events happen (exceeding the monthly budget, or a sudden increase in the number of resources). It would useful to have weekly reporting as it provides a more consolidated view of the data, allowing for easier trend analysis and identification of issues that require attention.

## Solution

Sending a weekly reporting on Slack each Friday at 9am (UTC) with the following metrics:
- Tags coverage: how many resources are untagged and list of most used tags
- Cost breakdown grouped by provider, region, account, and service

## Changes Made

- I used the current Slack integration to send the weekly reporting. I couldn't attach charts to the notifications as we currently use Slack webhooks and the only way to attach images is by uploading them to a remote server and adding the image link as a message attachment (I want to avoid uploading customer data to a remote server for data privacy). 

## How to Test

Enable Slack reporting by setting the `reporting` attribute under the `slack` section to `true`:

```
[slack]
  webhook="https://hooks.slack.com/services/ID/ID/ID"
  reporting=true
```
Then, invoke this [function](https://github.com/tailwarden/komiser/blob/e37056e0af504a36c7667a4d062480a92a8b383b/internal/internal.go#L89) outside of the cron job. 
 
## Screenshots

Tags coverage notification:

<img width="711" alt="Screenshot 2023-03-07 at 17 02 16" src="https://user-images.githubusercontent.com/10320205/223477904-86dd79c6-a4ab-4f2c-af89-e9cc9953b1f2.png">

Cost breakdown notification:
<img width="476" alt="Screenshot 2023-03-07 at 17 02 42" src="https://user-images.githubusercontent.com/10320205/223478014-87b0574e-4664-4972-8af4-293085ebb201.png">

## Notes
