### PR TITLE
feat: onClick legend in resources manager links to inventory

### DIFF
--- a/dashboard/components/dashboard/components/resources-manager/DashboardResourcesManagerCard.tsx
+++ b/dashboard/components/dashboard/components/resources-manager/DashboardResourcesManagerCard.tsx
@@ -27,7 +27,7 @@ function DashboardResourcesManagerCard({
   setExclude
 }: DashboardResourcesManagerCardProps) {
   const { chartData, options, select, handleChange } = useResourcesManagerChart(
-    { data, setQuery }
+    { data, setQuery, initialQuery: query }
   );
 
   return (

--- a/dashboard/components/dashboard/components/resources-manager/hooks/useResourcesManagerChart.tsx
+++ b/dashboard/components/dashboard/components/resources-manager/hooks/useResourcesManagerChart.tsx
@@ -76,6 +76,16 @@ function useResourcesManagerChart({
     },
     plugins: {
       legend: {
+        onClick(_, legendItem, legend) {
+          const clickedIndex = legendItem.index || 0;
+          // The labels are the providers in this case
+          const labels = legend.chart.data.labels ?? [];
+
+          window.open(
+            `./inventory?provider:IS:${labels[clickedIndex]}`,
+            '_blank'
+          );
+        },
         position: 'right',
         align: 'center',
         labels: {

--- a/dashboard/components/dashboard/components/resources-manager/hooks/useResourcesManagerChart.tsx
+++ b/dashboard/components/dashboard/components/resources-manager/hooks/useResourcesManagerChart.tsx
@@ -1,5 +1,5 @@
 import { ChartData, ChartOptions } from 'chart.js';
-import { Dispatch, SetStateAction } from 'react';
+import { Dispatch, SetStateAction, useState } from 'react';
 import formatNumber from '../../../../../utils/formatNumber';
 import {
   ResourcesManagerData,
@@ -15,11 +15,13 @@ export type ResourcesManagerChartProps = {
 type useResourcesManagerChartProps = {
   data: ResourcesManagerData | undefined;
   setQuery: Dispatch<SetStateAction<ResourcesManagerQuery>>;
+  initialQuery: ResourcesManagerQuery;
 };
 
 function useResourcesManagerChart({
   data,
-  setQuery
+  setQuery,
+  initialQuery
 }: useResourcesManagerChartProps) {
   const colors = ['#0072B2', '#FF8C00', '#228B22', '#FFD700', '#9932CC'];
 
@@ -34,6 +36,8 @@ function useResourcesManagerChart({
       'Custom views'
     ]
   }; */
+
+  const [currentQuery, setCurrentQuery] = useState(initialQuery);
 
   const select: ResourcesManagerGroupBySelectProps = {
     values: ['provider', 'service', 'region', 'account'],
@@ -82,7 +86,7 @@ function useResourcesManagerChart({
           const labels = legend.chart.data.labels ?? [];
 
           window.open(
-            `./inventory?provider:IS:${labels[clickedIndex]}`,
+            `./inventory?${currentQuery}:IS:${labels[clickedIndex]}`,
             '_blank'
           );
         },
@@ -135,6 +139,7 @@ function useResourcesManagerChart({
   };
 
   function handleChange(newValue: string) {
+    setCurrentQuery(newValue as ResourcesManagerQuery);
     setQuery(newValue as ResourcesManagerQuery);
   }
 


### PR DESCRIPTION
This PR adds the possiblity to click on a legend item in the `Ressource Manager` pie chart and be taken to `/inventory/?provider:IS:PROVIDER`. Note that this is not a very good approach IMHO, but it's quite hard making it work right with ChartJS. I would suggest going with this until we have bandwith to switch to a charting library which works well with React and makes customization easier (such as [Nivo](https://nivo.rocks)