### PR TITLE
Add GitHub Actions for testing & building komiser

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -76,8 +76,8 @@ jobs:
             go-bindata-assetfs -o internal/api/v1/template.go out/...
             sed -i -e 's/package main/package v1/g' internal/api/v1/template.go
       - run:
-         name: Run tests
-         command: |
+          name: Run tests
+          command: |
             make test
       - run:
           name: Build binary

--- a/.github/workflows/build_test.yml
+++ b/.github/workflows/build_test.yml
@@ -1,0 +1,59 @@
+name: "Build and Test komiser"
+on:
+  pull_request:
+    branches:
+      - master
+      - develop
+
+jobs:
+  build_test_dashboard:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+
+      - uses: actions/setup-node@v3
+        with:
+          node-version: 18
+          cache: "npm"
+          cache-dependency-path: "dashboard/package-lock.json"
+
+      - run: npm ci
+        working-directory: dashboard
+
+      - run: npm run lint
+        working-directory: dashboard
+
+      - run: npm test
+        working-directory: dashboard
+
+      - run: npm run build
+        working-directory: dashboard
+
+      - uses: actions/upload-artifact@v3
+        with:
+          name: dashboard-build
+          path: dashboard/out
+
+  build_test_cli:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Set up Go
+        uses: actions/setup-go@v4
+        with:
+          go-version: 1.20.2
+
+      - name: Install go-bin-data
+        run: |
+          go install -a -v github.com/go-bindata/go-bindata/...@latest
+          go install -v github.com/elazarl/go-bindata-assetfs/...
+
+      - name: Install dependencies
+        run: go mod download
+
+      - name: Test
+        run: make test
+
+      - name: Build
+        run: make build

--- a/.github/workflows/build_test_pr.yml
+++ b/.github/workflows/build_test_pr.yml
@@ -1,4 +1,4 @@
-name: "Build and Test komiser"
+name: "Build and Test Komiser PRs"
 on:
   pull_request:
     branches:

--- a/.github/workflows/build_test_pr.yml
+++ b/.github/workflows/build_test_pr.yml
@@ -1,9 +1,5 @@
 name: "Build and Test Komiser PRs"
-on:
-  pull_request:
-    branches:
-      - master
-      - develop
+on: pull_request
 
 jobs:
   build_test_dashboard:
@@ -29,11 +25,6 @@ jobs:
       - run: npm run build
         working-directory: dashboard
 
-      - uses: actions/upload-artifact@v3
-        with:
-          name: dashboard-build
-          path: dashboard/out
-
   build_test_cli:
     runs-on: ubuntu-latest
     steps:
@@ -43,11 +34,6 @@ jobs:
         uses: actions/setup-go@v4
         with:
           go-version: 1.20.2
-
-      - name: Install go-bin-data
-        run: |
-          go install -a -v github.com/go-bindata/go-bindata/...@latest
-          go install -v github.com/elazarl/go-bindata-assetfs/...
 
       - name: Install dependencies
         run: go mod download


### PR DESCRIPTION
This PR will set the first steps towards our effort to automate the release process and migrate the komiser repository to GitHub Actions. In the first step, I added two jobs that, for now, just build and test the `komiser` CLI, as well as the dashboard. The actions will run towards every PR.

Closes #372 