### PR TITLE
Add golangci-lint to PR action

### DIFF
--- a/.github/workflows/build_test_pr.yml
+++ b/.github/workflows/build_test_pr.yml
@@ -38,6 +38,9 @@ jobs:
       - name: Install dependencies
         run: go mod download
 
+      - name: golangci-lint
+        uses: golangci/golangci-lint-action@v3
+
       - name: Test
         run: make test
 


### PR DESCRIPTION
In order to check for style errors, we can leverage [`golangci-lint`](https://golangci-lint.run/) to do this in our CI