### PR TITLE
chore: remove golangci-lint from ci

### DIFF
--- a/.github/workflows/build_test_pr.yml
+++ b/.github/workflows/build_test_pr.yml
@@ -38,9 +38,6 @@ jobs:
       - name: Install dependencies
         run: go mod download
 
-      - name: golangci-lint
-        uses: golangci/golangci-lint-action@v3
-
       - name: Test
         run: make test
 


### PR DESCRIPTION
Remove the golangci-lint action for now, as this issue https://github.com/golangci/golangci-lint-action/issues/677 renders it useless to be run in CI