### PR TITLE
if opt in collect usage stats (slack & global)

### DIFF
--- a/handlers/csv_handler.go
+++ b/handlers/csv_handler.go
@@ -28,6 +28,10 @@ func (handler *ApiHandler) DownloadInventoryCSV(w http.ResponseWriter, r *http.R
 		return
 	}
 
+	if handler.telemetry {
+		handler.analytics.TrackEvent("exporting_csv", nil)
+	}
+
 	respondWithCSVDownload(resources, w, r)
 }
 

--- a/handlers/stats_handler.go
+++ b/handlers/stats_handler.go
@@ -50,6 +50,14 @@ func (handler *ApiHandler) StatsHandler(w http.ResponseWriter, r *http.Request) 
 		Costs:     cost.Sum,
 	}
 
+	if handler.telemetry {
+		handler.analytics.TrackEvent("global_stats", map[string]interface{}{
+			"costs":     cost.Sum,
+			"regions":   regions.Count,
+			"resources": resources.Count,
+		})
+	}
+
 	respondWithJSON(w, 200, output)
 }
 


### PR DESCRIPTION
In order to track the feature adoption of export CSV we're collecting its usage frequency (if opt-in by the end-user)