### PR TITLE
feat: calculate monthly cost for bucket

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -73,6 +73,7 @@ require (
 	cloud.google.com/go/compute v1.18.0 // indirect
 	cloud.google.com/go/compute/metadata v0.2.3 // indirect
 	cloud.google.com/go/iam v0.12.0 // indirect
+	cloud.google.com/go/monitoring v1.13.0 // indirect
 	cloud.google.com/go/storage v1.30.0 // indirect
 	github.com/Azure/azure-sdk-for-go/sdk/internal v1.1.2 // indirect
 	github.com/AzureAD/microsoft-authentication-library-for-go v0.8.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -9,6 +9,8 @@ cloud.google.com/go/compute/metadata v0.2.3 h1:mg4jlk7mCAj6xXp9UJ4fjI9VUI5rubuGB
 cloud.google.com/go/compute/metadata v0.2.3/go.mod h1:VAV5nSsACxMJvgaAuX6Pk2AawlZn8kiOGuCv6gTkwuA=
 cloud.google.com/go/iam v0.12.0 h1:DRtTY29b75ciH6Ov1PHb4/iat2CLCvrOm40Q0a6DFpE=
 cloud.google.com/go/iam v0.12.0/go.mod h1:knyHGviacl11zrtZUoDuYpDgLjvr28sLQaG0YB2GYAY=
+cloud.google.com/go/monitoring v1.13.0 h1:2qsrgXGVoRXpP7otZ14eE1I568zAa92sJSDPyOJvwjM=
+cloud.google.com/go/monitoring v1.13.0/go.mod h1:k2yMBAB1H9JT/QETjNkgdCGD9bPF712XiLTVr+cBrpw=
 cloud.google.com/go/storage v1.30.0 h1:g1yrbxAWOrvg/594228pETWkOi00MLTrOWfh56veU5o=
 cloud.google.com/go/storage v1.30.0/go.mod h1:xAVretHSROm1BQX4IIsoVgJqw0LqOyX+I/O2GzRAzdE=
 github.com/Azure/azure-sdk-for-go/sdk/azcore v1.3.1 h1:gVXuXcWd1i4C2Ruxe321aU+IKGaStvGB/S90PUPB/W8=

--- a/providers/gcp/storage/storage.go
+++ b/providers/gcp/storage/storage.go
@@ -2,17 +2,62 @@ package storage
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"strings"
 	"time"
 
+	monitoring "cloud.google.com/go/monitoring/apiv3"
+	monitoringpb "cloud.google.com/go/monitoring/apiv3/v2/monitoringpb"
 	"cloud.google.com/go/storage"
+	"github.com/golang/protobuf/ptypes/duration"
+	"github.com/golang/protobuf/ptypes/timestamp"
 	log "github.com/sirupsen/logrus"
 	"github.com/tailwarden/komiser/models"
 	"github.com/tailwarden/komiser/providers"
 	"google.golang.org/api/iterator"
 	"google.golang.org/api/option"
 )
+
+func GetBucketSize(ctx context.Context, client providers.ProviderClient, bucketName string) (int64, error) {
+	monitoringClient, err := monitoring.NewMetricClient(ctx, option.WithCredentials(client.GCPClient.Credentials))
+	if err != nil {
+		log.WithError(err).Debug("failed to create monitoring client")
+		return 0, err
+	}
+
+	req := &monitoringpb.ListTimeSeriesRequest{
+		Name:   "projects/" + client.GCPClient.Credentials.ProjectID,
+		Filter: "metric.type=\"storage.googleapis.com/storage/total_bytes\" resource.type=\"gcs_bucket\" resource.label.bucket_name=\"" + bucketName + "\"",
+		Interval: &monitoringpb.TimeInterval{
+			EndTime:   &timestamp.Timestamp{Seconds: time.Now().Unix()},
+			StartTime: &timestamp.Timestamp{Seconds: time.Now().Add(-1 * time.Hour).Unix()},
+		},
+		Aggregation: &monitoringpb.Aggregation{
+			AlignmentPeriod:  &duration.Duration{Seconds: 60},
+			PerSeriesAligner: monitoringpb.Aggregation_ALIGN_MEAN,
+		},
+	}
+
+	res := monitoringClient.ListTimeSeries(ctx, req)
+
+	for {
+		series, err := res.Next()
+		if err == iterator.Done {
+			break
+		}
+		if err != nil {
+			log.WithError(err).Debug("failed to list time series")
+			return 0, err
+		}
+
+		for _, point := range series.Points {
+			return int64(point.Value.GetDoubleValue()), nil
+		}
+	}
+
+	return 0, errors.New("no data found")
+}
 
 func Buckets(ctx context.Context, client providers.ProviderClient) ([]models.Resource, error) {
 	resources := make([]models.Resource, 0)
@@ -43,6 +88,17 @@ func Buckets(ctx context.Context, client providers.ProviderClient) ([]models.Res
 			}
 		}
 
+		monthlyCost := 0.0
+
+		bucketSize, err := GetBucketSize(ctx, client, bucket.Name)
+		if err != nil {
+			log.WithError(err).Errorf("failed to get bucket size")
+		}
+
+		if bucketSize > 0 {
+			monthlyCost = float64(bucketSize) * 0.20
+		}
+
 		resources = append(resources, models.Resource{
 			Provider:   "GCP",
 			Account:    client.Name,
@@ -51,6 +107,7 @@ func Buckets(ctx context.Context, client providers.ProviderClient) ([]models.Res
 			ResourceId: bucket.Name,
 			Region:     strings.ToLower(bucket.Location),
 			Tags:       tags,
+			Cost:       monthlyCost,
 			FetchedAt:  time.Now(),
 			Link:       fmt.Sprintf("https://console.cloud.google.com/storage/browser/%s?project=%s", bucket.Name, client.GCPClient.Credentials.ProjectID),
 		})

--- a/providers/gcp/storage/storage.go
+++ b/providers/gcp/storage/storage.go
@@ -62,6 +62,15 @@ func GetBucketSize(ctx context.Context, client providers.ProviderClient, bucketN
 	return 0, errors.New("no data found")
 }
 
+func getPricingForGCPBuckets() map[string]float64 {
+	return map[string]float64{
+		"STANDARD": 0.20,
+		"NEARLINE": 0.10,
+		"COLDLINE": 0.01,
+		"ARCHIVE":  0.005,
+	}
+}
+
 func Buckets(ctx context.Context, client providers.ProviderClient) ([]models.Resource, error) {
 	resources := make([]models.Resource, 0)
 
@@ -102,7 +111,7 @@ func Buckets(ctx context.Context, client providers.ProviderClient) ([]models.Res
 
 		if bucketSize > 0 {
 			bucketSizeInGB := float64(bucketSize) / 1024 / 1024 / 1024
-			monthlyCost = float64(bucketSizeInGB) * 0.20
+			monthlyCost = float64(bucketSizeInGB) * getPricingForGCPBuckets()[strings.ToUpper(bucket.StorageClass)]
 		}
 
 		resources = append(resources, models.Resource{

--- a/providers/gcp/storage/storage.go
+++ b/providers/gcp/storage/storage.go
@@ -31,7 +31,7 @@ func GetBucketSize(ctx context.Context, client providers.ProviderClient, bucketN
 
 	req := &monitoringpb.ListTimeSeriesRequest{
 		Name:   "projects/" + client.GCPClient.Credentials.ProjectID,
-		Filter: "metric.type=\"storage.googleapis.com/storage/total_bytes\" resource.type=\"gcs_bucket\" resource.label.bucket_name=\"" + bucketName + "\"",
+		Filter: fmt.Sprintf(`metric.type="storage.googleapis.com/storage/total_bytes" resource.type="gcs_bucket" resource.label.bucket_name="%s"`, bucketName),
 		Interval: &monitoringpb.TimeInterval{
 			StartTime: &timestamp.Timestamp{Seconds: beginningOfMonth},
 			EndTime:   &timestamp.Timestamp{Seconds: time.Now().Unix()},

--- a/providers/gcp/storage/storage.go
+++ b/providers/gcp/storage/storage.go
@@ -19,6 +19,7 @@ import (
 	"google.golang.org/api/option"
 )
 
+// GetBucketSize returns the size of a bucket in bytes
 func GetBucketSize(ctx context.Context, client providers.ProviderClient, bucketName string) (int64, error) {
 	monitoringClient, err := monitoring.NewMetricClient(ctx, option.WithCredentials(client.GCPClient.Credentials))
 	if err != nil {
@@ -26,16 +27,18 @@ func GetBucketSize(ctx context.Context, client providers.ProviderClient, bucketN
 		return 0, err
 	}
 
+	beginningOfMonth := time.Date(time.Now().Year(), time.Now().Month(), 1, 0, 0, 0, 0, time.UTC).Unix()
+
 	req := &monitoringpb.ListTimeSeriesRequest{
 		Name:   "projects/" + client.GCPClient.Credentials.ProjectID,
 		Filter: "metric.type=\"storage.googleapis.com/storage/total_bytes\" resource.type=\"gcs_bucket\" resource.label.bucket_name=\"" + bucketName + "\"",
 		Interval: &monitoringpb.TimeInterval{
+			StartTime: &timestamp.Timestamp{Seconds: beginningOfMonth},
 			EndTime:   &timestamp.Timestamp{Seconds: time.Now().Unix()},
-			StartTime: &timestamp.Timestamp{Seconds: time.Now().Add(-1 * time.Hour).Unix()},
 		},
 		Aggregation: &monitoringpb.Aggregation{
 			AlignmentPeriod:  &duration.Duration{Seconds: 60},
-			PerSeriesAligner: monitoringpb.Aggregation_ALIGN_MEAN,
+			PerSeriesAligner: monitoringpb.Aggregation_ALIGN_SUM,
 		},
 	}
 
@@ -92,11 +95,14 @@ func Buckets(ctx context.Context, client providers.ProviderClient) ([]models.Res
 
 		bucketSize, err := GetBucketSize(ctx, client, bucket.Name)
 		if err != nil {
-			log.WithError(err).Errorf("failed to get bucket size")
+			log.WithError(err).WithFields(log.Fields{
+				"bucket": bucket.Name,
+			}).Debug("failed to get bucket size, skipping cost calculation")
 		}
 
 		if bucketSize > 0 {
-			monthlyCost = float64(bucketSize) * 0.20
+			bucketSizeInGB := float64(bucketSize) / 1024 / 1024 / 1024
+			monthlyCost = float64(bucketSizeInGB) * 0.20
 		}
 
 		resources = append(resources, models.Resource{

--- a/providers/gcp/storage/storage.go
+++ b/providers/gcp/storage/storage.go
@@ -7,7 +7,7 @@ import (
 	"strings"
 	"time"
 
-	monitoring "cloud.google.com/go/monitoring/apiv3"
+	monitoring "cloud.google.com/go/monitoring/apiv3/v2"
 	monitoringpb "cloud.google.com/go/monitoring/apiv3/v2/monitoringpb"
 	"cloud.google.com/go/storage"
 	"github.com/golang/protobuf/ptypes/duration"


### PR DESCRIPTION
This PR will add cost estimation for GCP buckets. It's not very trivial to get the bucket size unfortunately, so we use the [GCP Monitoring API](https://cloud.google.com/monitoring/api/v3) to gather metrics about the total bucket size. The cost estimation is done based on `us-central-1` region only for now. 

Note that for this to work, you'll need the `monitoring.timeSeries.list` permission in your service account.