### PR TITLE
chore: docker, copy binary from dist

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,9 +10,8 @@ RUN echo "Running on $BUILDPLATFORM, building for $TARGETPLATFORM" > /log
 ENV SEGMENT_WRITE_KEY $SEGMENT_WRITE_KEY
 ENV VERSION $VERSION
 
-RUN apk update && apk add curl
-RUN curl -L https://cli.komiser.io/$VERSION/komiser_Linux_x86_64  -o /usr/bin/komiser && \
-    chmod +x /usr/bin/komiser && \
+COPY komiser /usr/bin/komiser
+RUN chmod +x /usr/bin/komiser && \
     mkdir /lib64 && ln -s /lib/libc.musl-x86_64.so.1 /lib64/ld-linux-x86-64.so.2
 
 EXPOSE $PORT


### PR DESCRIPTION
During `docker build` we used to grab the binary from remote S3, which leaded to the Docker image sometimes not having the latest binary file. This PR changes the Dockerfile to copy the binary from the local /dist folder, which is always up to date after building.