### PR TITLE
fix: cloud map error state offline mode

### DIFF
--- a/dashboard/components/dashboard/components/cloud-map/DashboardCloudMapError.tsx
+++ b/dashboard/components/dashboard/components/cloud-map/DashboardCloudMapError.tsx
@@ -39,7 +39,7 @@ function DashboardCloudMapError({ fetch }: DashboardCloudMapErrorProps) {
       <div className="mt-8"></div>
       <div className="-mx-6 -ml-20 min-w-full">
         <picture>
-          <img src="/assets/img/others/world.svg" alt="world map" />
+          <img src="/assets/img/others/world.svg" alt="" />
         </picture>
       </div>
       <div className="mt-12"></div>

--- a/dashboard/package-lock.json
+++ b/dashboard/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "komiser-dashboard",
-  "version": "3.0.6",
+  "version": "3.0.10",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "komiser-dashboard",
-      "version": "3.0.6",
+      "version": "3.0.10",
       "dependencies": {
         "@sentry/react": "^7.41.0",
         "@sentry/tracing": "^7.41.0",


### PR DESCRIPTION
## Problem
If a given user has loaded the Komiser dashboard, visited the Inventory page, lost internet connection or closed the server, then went back to the dashboard, they will be served either with a default browser error screen (i.e.: there is no internet connection...) or with the Next.js cached HTML/JS version of the page, which shows the dashboard widgets with the error state.

In the case they receive the cached version, the cloud map error state would render like this:
![image](https://user-images.githubusercontent.com/13384559/229782035-3250afd4-7e4b-4c67-b2bf-81525a19fa69.png)

We use an SVG to display the world map as a placeholder, so since there is no connection to load the file, it displays its alt text instead.

## Solution
Remove the alt property, so in this specific scenario of no internet connection, they would just see a blank space where the map should be.

The error state (not in offline mode) can be observed from the Storybook: 
https://storybook.komiser.io/?path=/story/komiser-widgets-cloud-map--error