### PR TITLE
feat: add EXISTS/NOT_EXISTS query option for specific tags filter

### DIFF
--- a/dashboard/components/inventory/components/filter/InventoryFilter.tsx
+++ b/dashboard/components/inventory/components/filter/InventoryFilter.tsx
@@ -125,6 +125,8 @@ function InventoryFilter({
                         data &&
                         data.operator !== 'IS_EMPTY' &&
                         data.operator !== 'IS_NOT_EMPTY' &&
+                        data.operator !== 'EXISTS' &&
+                        data.operator !== 'NOT_EXISTS' &&
                         data.values &&
                         data.values.length === 0
                       }

--- a/dashboard/components/inventory/components/filter/InventoryFilterOperator.tsx
+++ b/dashboard/components/inventory/components/filter/InventoryFilterOperator.tsx
@@ -22,6 +22,12 @@ const inventoryFilterOperatorOptions: InventoryFilterOperatorOptionsProps[] = [
   { label: 'is not empty', value: 'IS_NOT_EMPTY' }
 ];
 
+const inventoryFilterOperatorSpecificTagsOptions: InventoryFilterOperatorOptionsProps[] =
+  [
+    { label: 'does exist', value: 'EXISTS' },
+    { label: 'does not exist', value: 'NOT_EXISTS' }
+  ];
+
 const inventoryFilterOperatorAllTagsOptions: InventoryFilterOperatorOptionsProps[] =
   [
     { label: 'which are empty', value: 'IS_EMPTY' },
@@ -82,6 +88,23 @@ function InventoryFilterOperator({
             gap="md"
             disabled={data.field === 'tag' && !data.tagKey}
             transition={false}
+            onClick={() => handleOperator(option.value)}
+          >
+            {option.label}
+          </Button>
+        ))}
+
+      {/* Operators list for specific tags */}
+      {data.field === 'tag' &&
+        inventoryFilterOperatorSpecificTagsOptions.map((option, idx) => (
+          <Button
+            key={idx}
+            size="sm"
+            style="ghost"
+            align="left"
+            gap="md"
+            transition={false}
+            disabled={data.field === 'tag' && !data.tagKey}
             onClick={() => handleOperator(option.value)}
           >
             {option.label}

--- a/dashboard/components/inventory/components/filter/InventoryFilterSummary.tsx
+++ b/dashboard/components/inventory/components/filter/InventoryFilterSummary.tsx
@@ -42,6 +42,8 @@ function InventoryFilterSummary({
     if (param === 'BETWEEN') return 'is between';
     if (param === 'GREATER_THAN') return 'is greater than';
     if (param === 'LESS_THAN') return 'is less than';
+    if (param === 'EXISTS') return 'does exist';
+    if (param === 'NOT_EXISTS') return 'does not exist';
     return param;
   }
 

--- a/dashboard/components/inventory/components/filter/InventoryFilterValue.tsx
+++ b/dashboard/components/inventory/components/filter/InventoryFilterValue.tsx
@@ -33,80 +33,71 @@ function InventoryFilterValue({
   const [options, setOptions] = useState<Options | undefined>();
 
   useEffect(() => {
-    let mounted = true;
-
-    if (data.operator === 'IS_EMPTY' || data.operator === 'IS_NOT_EMPTY') {
+    if (
+      data.operator === 'IS_EMPTY' ||
+      data.operator === 'IS_NOT_EMPTY' ||
+      data.operator === 'EXISTS' ||
+      data.operator === 'NOT_EXISTS'
+    ) {
       cleanValues();
       setOptions(undefined);
     } else {
       if (data.field === 'provider') {
         settingsService.getProviders().then(res => {
-          if (mounted) {
-            if (res === Error) {
-              setToast({
-                hasError: true,
-                title: `There was an error when fetching the cloud providers`,
-                message: `Please refresh the page and try again.`
-              });
-            } else {
-              setOptions(res);
-            }
+          if (res === Error) {
+            setToast({
+              hasError: true,
+              title: `There was an error when fetching the cloud providers`,
+              message: `Please refresh the page and try again.`
+            });
+          } else {
+            setOptions(res);
           }
         });
       }
 
       if (data.field === 'account') {
         settingsService.getAccounts().then(res => {
-          if (mounted) {
-            if (res === Error) {
-              setToast({
-                hasError: true,
-                title: `There was an error when fetching the cloud accounts`,
-                message: `Please refresh the page and try again.`
-              });
-            } else {
-              setOptions(res);
-            }
+          if (res === Error) {
+            setToast({
+              hasError: true,
+              title: `There was an error when fetching the cloud accounts`,
+              message: `Please refresh the page and try again.`
+            });
+          } else {
+            setOptions(res);
           }
         });
       }
 
       if (data.field === 'region') {
         settingsService.getRegions().then(res => {
-          if (mounted) {
-            if (res === Error) {
-              setToast({
-                hasError: true,
-                title: `There was an error when fetching the cloud regions`,
-                message: `Please refresh the page and try again.`
-              });
-            } else {
-              setOptions(res);
-            }
+          if (res === Error) {
+            setToast({
+              hasError: true,
+              title: `There was an error when fetching the cloud regions`,
+              message: `Please refresh the page and try again.`
+            });
+          } else {
+            setOptions(res);
           }
         });
       }
 
       if (data.field === 'service') {
         settingsService.getServices().then(res => {
-          if (mounted) {
-            if (res === Error) {
-              setToast({
-                hasError: true,
-                title: `There was an error when fetching the cloud services`,
-                message: `Please refresh the page and try again.`
-              });
-            } else {
-              setOptions(res);
-            }
+          if (res === Error) {
+            setToast({
+              hasError: true,
+              title: `There was an error when fetching the cloud services`,
+              message: `Please refresh the page and try again.`
+            });
+          } else {
+            setOptions(res);
           }
         });
       }
     }
-
-    return () => {
-      mounted = false;
-    };
   }, []);
 
   return (
@@ -131,7 +122,9 @@ function InventoryFilterValue({
       {!options &&
         data.field !== 'cost' &&
         data.operator !== 'IS_EMPTY' &&
-        data.operator !== 'IS_NOT_EMPTY' && (
+        data.operator !== 'IS_NOT_EMPTY' &&
+        data.operator !== 'EXISTS' &&
+        data.operator !== 'NOT_EXISTS' && (
           <div className="pl-1 pt-2 pr-4 pb-2">
             <Input
               type="text"

--- a/dashboard/components/inventory/hooks/useInventory/helpers/parseURLParams.ts
+++ b/dashboard/components/inventory/hooks/useInventory/helpers/parseURLParams.ts
@@ -32,7 +32,9 @@ function parseURLParams(
     if (formatString.length > 2) {
       if (
         formatString.indexOf('IS_EMPTY') !== -1 ||
-        formatString.indexOf('IS_NOT_EMPTY') !== -1
+        formatString.indexOf('IS_NOT_EMPTY') !== -1 ||
+        formatString.indexOf('EXISTS') !== -1 ||
+        formatString.indexOf('NOT_EXISTS') !== -1
       ) {
         const key = formatString.slice(1, formatString.length - 1).join(':');
 

--- a/handlers/resources_handler.go
+++ b/handlers/resources_handler.go
@@ -250,16 +250,16 @@ func (handler *ApiHandler) FilterResourcesHandler(w http.ResponseWriter, r *http
 	}
 
 	if filterWithTags {
-		query := fmt.Sprintf("SELECT id, resource_id, provider, account, service, region, name, created_at, fetched_at,cost, metadata, tags,link FROM resources CROSS JOIN jsonb_array_elements(tags) AS res WHERE %s ORDER BY id LIMIT %d OFFSET %d", whereClause, limit, skip)
+		query := fmt.Sprintf("SELECT DISTINCT id, resource_id, provider, account, service, region, name, created_at, fetched_at,cost, metadata, tags,link FROM resources CROSS JOIN jsonb_array_elements(tags) AS res WHERE %s ORDER BY id LIMIT %d OFFSET %d", whereClause, limit, skip)
 		if len(view.Exclude) > 0 {
 			s, _ := json.Marshal(view.Exclude)
-			query = fmt.Sprintf("SELECT id, resource_id, provider, account, service, region, name, created_at, fetched_at,cost, metadata, tags,link FROM resources CROSS JOIN jsonb_array_elements(tags) AS res WHERE %s AND id NOT IN (%s) ORDER BY id LIMIT %d OFFSET %d", whereClause, strings.Trim(string(s), "[]"), limit, skip)
+			query = fmt.Sprintf("SELECT DISTINCT id, resource_id, provider, account, service, region, name, created_at, fetched_at,cost, metadata, tags,link FROM resources CROSS JOIN jsonb_array_elements(tags) AS res WHERE %s AND id NOT IN (%s) ORDER BY id LIMIT %d OFFSET %d", whereClause, strings.Trim(string(s), "[]"), limit, skip)
 		}
 		if handler.db.Dialect().Name() == dialect.SQLite {
-			query = fmt.Sprintf("SELECT resources.id, resources.resource_id, resources.provider, resources.account, resources.service, resources.region, resources.name, resources.created_at, resources.fetched_at, resources.cost, resources.metadata, resources.tags, resources.link FROM resources CROSS JOIN json_each(tags) WHERE type='object' AND %s ORDER BY resources.id LIMIT %d OFFSET %d", whereClause, limit, skip)
+			query = fmt.Sprintf("SELECT DISTINCT resources.id, resources.resource_id, resources.provider, resources.account, resources.service, resources.region, resources.name, resources.created_at, resources.fetched_at, resources.cost, resources.metadata, resources.tags, resources.link FROM resources CROSS JOIN json_each(tags) WHERE type='object' AND %s ORDER BY resources.id LIMIT %d OFFSET %d", whereClause, limit, skip)
 			if len(view.Exclude) > 0 {
 				s, _ := json.Marshal(view.Exclude)
-				query = fmt.Sprintf("SELECT resources.id, resources.resource_id, resources.provider, resources.account, resources.service, resources.region, resources.name, resources.created_at, resources.fetched_at, resources.cost, resources.metadata, resources.tags, resources.link FROM resources CROSS JOIN json_each(tags) WHERE resources.id NOT IN (%s) AND type='object' AND %s ORDER BY resources.id LIMIT %d OFFSET %d", strings.Trim(string(s), "[]"), whereClause, limit, skip)
+				query = fmt.Sprintf("SELECT DISTINCT resources.id, resources.resource_id, resources.provider, resources.account, resources.service, resources.region, resources.name, resources.created_at, resources.fetched_at, resources.cost, resources.metadata, resources.tags, resources.link FROM resources CROSS JOIN json_each(tags) WHERE resources.id NOT IN (%s) AND type='object' AND %s ORDER BY resources.id LIMIT %d OFFSET %d", strings.Trim(string(s), "[]"), whereClause, limit, skip)
 			}
 		}
 

--- a/handlers/stats_handler.go
+++ b/handlers/stats_handler.go
@@ -145,6 +145,18 @@ func (handler *ApiHandler) FilterStatsHandler(w http.ResponseWriter, r *http.Req
 				} else {
 					whereQueries = append(whereQueries, fmt.Sprintf("((res->>'key' = '%s') AND (res->>'value' != ''))", key))
 				}
+			case "EXISTS":
+				if handler.db.Dialect().Name() == dialect.SQLite {
+					whereQueries = append(whereQueries, fmt.Sprintf("((json_extract(value, '$.key') = '%s'))", key))
+				} else {
+					whereQueries = append(whereQueries, fmt.Sprintf("((res->>'key' = '%s'))", key))
+				}
+			case "NOT_EXISTS":
+				if handler.db.Dialect().Name() == dialect.SQLite {
+					whereQueries = append(whereQueries, fmt.Sprintf(`(NOT EXISTS (SELECT 1 FROM json_each(resources.tags) WHERE (json_extract(value, '$.key') = '%s')))`, key))
+				} else {
+					whereQueries = append(whereQueries, fmt.Sprintf("((res->>'key' != '%s'))", key))
+				}
 			default:
 				respondWithError(w, http.StatusBadRequest, "Operation is invalid or not supported")
 				return


### PR DESCRIPTION
This PR adds two new filters for specific tags, the `does exist/EXISTS` and `does not exist/NOT_EXISTS` filters. The `EXISTS` filter checks if a given tag key is present in a row, respectively `NOT_EXISTS` returns all rows that do not have that key present.

<img width="312" alt="Screenshot 2023-04-04 at 16 36 42" src="https://user-images.githubusercontent.com/964419/229827248-702ea895-0c76-474c-8103-79206c04824c.png">
