### PR TITLE
Add Support for Custom IAM roles in GCP

### DIFF
--- a/providers/gcp/gcp.go
+++ b/providers/gcp/gcp.go
@@ -8,6 +8,7 @@ import (
 	"github.com/tailwarden/komiser/providers/gcp/bigquery"
 	certficate "github.com/tailwarden/komiser/providers/gcp/certificate"
 	"github.com/tailwarden/komiser/providers/gcp/compute"
+	"github.com/tailwarden/komiser/providers/gcp/iam"
 	"github.com/tailwarden/komiser/providers/gcp/storage"
 	"github.com/tailwarden/komiser/utils"
 	"github.com/uptrace/bun"
@@ -19,6 +20,7 @@ func listOfSupportedServices() []providers.FetchDataFunction {
 		storage.Buckets,
 		bigquery.BigQueryTables,
 		certficate.Certificates,
+		iam.IamRoles,
 	}
 }
 

--- a/providers/gcp/iam/iam.go
+++ b/providers/gcp/iam/iam.go
@@ -45,8 +45,14 @@ func IamRoles(ctx context.Context, client providers.ProviderClient) ([]models.Re
 			FetchedAt: time.Now(),
 			Link:      fmt.Sprintf("https://console.cloud.google.com/iam-admin/roles/details/%s?project=%s", targetForUrl, client.GCPClient.Credentials.ProjectID),
 		})
-
 	}
+	logrus.WithFields(logrus.Fields{
+		"provider":  "GCP",
+		"account":   client.Name,
+		"service":   "IAM Custom Roles",
+		"resources": len(resources),
+	}).Info("Fetched resources")
+
 	return resources, nil
 
 }

--- a/providers/gcp/iam/iam.go
+++ b/providers/gcp/iam/iam.go
@@ -1,0 +1,52 @@
+package iam
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/sirupsen/logrus"
+	"github.com/tailwarden/komiser/models"
+	"github.com/tailwarden/komiser/providers"
+	"google.golang.org/api/iam/v1"
+	"google.golang.org/api/option"
+)
+
+func IamRoles(ctx context.Context, client providers.ProviderClient) ([]models.Resource, error) {
+	resources := make([]models.Resource, 0)
+
+	iamService, err := iam.NewService(ctx, option.WithCredentials(client.GCPClient.Credentials))
+	if err != nil {
+		logrus.WithError(err).Errorf("failed to create IAM roles service")
+		return resources, err
+	}
+
+	roles, err := iamService.Projects.Roles.List(
+		"projects/" + client.GCPClient.Credentials.ProjectID,
+	).Do()
+	if err != nil {
+		logrus.WithError(err).Errorf("failed to list IAM roles")
+		return resources, err
+	}
+
+	for _, role := range roles.Roles {
+		targetForUrl := strings.Replace(role.Name, "/", "<", -1)
+
+		resources = append(resources, models.Resource{
+			Provider:   "GCP",
+			Account:    client.Name,
+			Service:    "IAM Roles",
+			ResourceId: role.Name,
+			Name:       role.Title,
+			Metadata: map[string]string{
+				"Description": role.Description,
+			},
+			FetchedAt: time.Now(),
+			Link:      fmt.Sprintf("https://console.cloud.google.com/iam-admin/roles/details/%s?project=%s", targetForUrl, client.GCPClient.Credentials.ProjectID),
+		})
+
+	}
+	return resources, nil
+
+}


### PR DESCRIPTION
## Problem
Add Support for IAM Roles (only custom roles will be fetched, the predefined 300 roles aren't displayed) in GCP
Closes #671 

## Solution
![Screenshot_2023-04-07-21-58-32_4920x1920](https://user-images.githubusercontent.com/55556994/230643798-e1d5ea13-8dbf-472b-b6ab-6b530044b2c0.png)

## Checklist

- [x] Code follows the <a href="https://github.com/tailwarden/komiser/blob/master/CONTRIBUTING.md">contributing</a> guidelines
- [x] Changes have been thoroughly tested
- [ ] <a href="https://github.com/tailwarden/docs.komiser.io">Documentation</a> has been updated, if necessary
- [x] Any dependencies have been added to the project, if necessary
