### PR TITLE
Add Support for API Gateways in GCP

### DIFF
--- a/providers/gcp/gateway/gateways.go
+++ b/providers/gcp/gateway/gateways.go
@@ -1,0 +1,107 @@
+package gateway
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/sirupsen/logrus"
+	"github.com/tailwarden/komiser/models"
+	"github.com/tailwarden/komiser/providers"
+	"google.golang.org/api/apigateway/v1"
+	"google.golang.org/api/compute/v1"
+	"google.golang.org/api/option"
+)
+
+func ApiGateways(ctx context.Context, client providers.ProviderClient) ([]models.Resource, error) {
+	resources := make([]models.Resource, 0)
+
+	regions, err := listGCPRegions(client.GCPClient.Credentials.ProjectID, option.WithCredentials(client.GCPClient.Credentials))
+	if err != nil {
+		logrus.WithError(err).Errorf("failed to list zones to fetch api gateways")
+		return resources, err
+	}
+
+	apiGatewayService, err := apigateway.NewService(ctx, option.WithCredentials(client.GCPClient.Credentials))
+	if err != nil {
+		logrus.WithError(err).Errorf("failed to create API Gateway service")
+		return resources, err
+	}
+
+RegionsLoop:
+	for _, regionName := range regions {
+		apiGateways, err := apiGatewayService.Projects.Locations.Gateways.List(
+			"projects/" + client.GCPClient.Credentials.ProjectID + "/locations/" + regionName,
+		).Do()
+		if err != nil {
+			if err.Error() == "googleapi: Error 403: Location "+regionName+" is not found or access is unauthorized., forbidden" {
+				continue RegionsLoop
+			} else {
+				logrus.WithError(err).Errorf("failed to list API Gateways")
+				return resources, err
+
+			}
+		}
+
+		for _, apiGateway := range apiGateways.Gateways {
+			fmt.Printf("%+v\n", apiGateway)
+
+			layout := "2006-01-02T15:04:05.999999999Z"
+			parsedCreatedTime, err := time.Parse(layout, apiGateway.CreateTime)
+			if err != nil {
+				logrus.WithError(err).Errorf("failed to parse create time for API Gateways")
+				return resources, err
+			}
+
+			resources = append(resources, models.Resource{
+				Provider:   "GCP",
+				Account:    client.Name,
+				Service:    "API Gateways",
+				ResourceId: apiGateway.Name,
+				Name:       apiGateway.DisplayName,
+				CreatedAt:  parsedCreatedTime,
+				Region:     regionName,
+				Metadata: map[string]string{
+					"API Config":       apiGateway.ApiConfig,
+					"Default Hostname": apiGateway.DefaultHostname,
+					"State":            apiGateway.State,
+				},
+				FetchedAt: time.Now(),
+				Link:      fmt.Sprintf("https://console.cloud.google.com/api-gateway/gateway/%s/location/%s?project=%s", apiGateway.DisplayName, regionName, client.GCPClient.Credentials.ProjectID),
+			})
+
+		}
+
+	}
+
+	logrus.WithFields(logrus.Fields{
+		"provider":  "GCP",
+		"account":   client.Name,
+		"service":   "API Gateway",
+		"resources": len(resources),
+	}).Info("Fetched resources")
+
+	return resources, nil
+}
+
+func listGCPRegions(projectId string, creds option.ClientOption) ([]string, error) {
+	var regions []string
+
+	ctx := context.Background()
+	computeService, err := compute.NewService(ctx, creds)
+	if err != nil {
+		logrus.WithError(err).Errorf("failed to create new service for fetching GCP regions for api gateway")
+		return nil, err
+	}
+
+	regionList, err := computeService.Regions.List(projectId).Do()
+	if err != nil {
+		logrus.WithError(err).Errorf("failed to list regions for fetching GCP regions for api gateway")
+		return nil, err
+	}
+
+	for _, region := range regionList.Items {
+		regions = append(regions, region.Name)
+	}
+	return regions, nil
+}

--- a/providers/gcp/gateway/gateways.go
+++ b/providers/gcp/gateway/gateways.go
@@ -44,10 +44,7 @@ RegionsLoop:
 		}
 
 		for _, apiGateway := range apiGateways.Gateways {
-			fmt.Printf("%+v\n", apiGateway)
-
-			layout := "2006-01-02T15:04:05.999999999Z"
-			parsedCreatedTime, err := time.Parse(layout, apiGateway.CreateTime)
+			parsedCreatedTime, err := time.Parse(time.RFC3339Nano, apiGateway.CreateTime)
 			if err != nil {
 				logrus.WithError(err).Errorf("failed to parse create time for API Gateways")
 				return resources, err

--- a/providers/gcp/gcp.go
+++ b/providers/gcp/gcp.go
@@ -9,6 +9,7 @@ import (
 	certficate "github.com/tailwarden/komiser/providers/gcp/certificate"
 	"github.com/tailwarden/komiser/providers/gcp/compute"
 	"github.com/tailwarden/komiser/providers/gcp/container"
+	"github.com/tailwarden/komiser/providers/gcp/gateway"
 	"github.com/tailwarden/komiser/providers/gcp/iam"
 	"github.com/tailwarden/komiser/providers/gcp/kms"
 	"github.com/tailwarden/komiser/providers/gcp/redis"
@@ -31,6 +32,7 @@ func listOfSupportedServices() []providers.FetchDataFunction {
 		redis.Instances,
 		container.Clusters,
 		kms.Keys,
+		gateway.ApiGateways,
 	}
 }
 


### PR DESCRIPTION
## Problem
Closes #675 

## Solution
![Screenshot_2023-04-10-20-39-14_4920x1920](https://user-images.githubusercontent.com/55556994/230929373-ca608d32-a953-491c-a3bd-1dcffd062220.png)

## Notes
Just like Redis support #709, this also has to query all the zones and does not work with the "global" tag. As of now, both of the methods are called separately hence the same regions call happen twice.

In the near future, a separate feature to just make 1 call and then use that in both the places saving up time as well as compute.

## Checklist

- [x] Code follows the <a href="https://github.com/tailwarden/komiser/blob/master/CONTRIBUTING.md">contributing</a> guidelines
- [x] Changes have been thoroughly tested
- [ ] <a href="https://github.com/tailwarden/docs.komiser.io">Documentation</a> has been updated, if necessary
- [x] Any dependencies have been added to the project, if necessary
