### PR TITLE
Added Sao Paulo to cloud map

### DIFF
--- a/utils/regions.go
+++ b/utils/regions.go
@@ -137,6 +137,12 @@ func getAWSRegions() []Location {
 			Latitude:  "26.066700",
 			Longitude: "50.557700",
 		},
+		{
+			Name:      "Sao Paulo",
+			Label:     "sa-east-1",
+			Latitude:  "-33.469120",
+			Longitude: "-70.641997",
+		},
 	}
 }
 


### PR DESCRIPTION
## Problem

Sao Paulo region was missing in the cloud map widget

![image](https://user-images.githubusercontent.com/10320205/231163327-7b7de9cc-d9a0-4426-be0e-5eb71ad3eb0c.png)