### PR TITLE
Only Parse Used Created Policies from AWS

### DIFF
--- a/providers/aws/iam/policies.go
+++ b/providers/aws/iam/policies.go
@@ -9,13 +9,16 @@ import (
 
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/service/iam"
+	"github.com/aws/aws-sdk-go-v2/service/iam/types"
 	. "github.com/tailwarden/komiser/models"
 	. "github.com/tailwarden/komiser/providers"
 )
 
 func Policies(ctx context.Context, client ProviderClient) ([]Resource, error) {
 	resources := make([]Resource, 0)
-	var configPolicies iam.ListPoliciesInput
+	configPolicies := iam.ListPoliciesInput{
+		Scope: types.PolicyScopeTypeLocal,
+	}
 	var configTags iam.ListPolicyTagsInput
 	iamClient := iam.NewFromConfig(*client.AWSClient)
 
@@ -26,44 +29,41 @@ func Policies(ctx context.Context, client ProviderClient) ([]Resource, error) {
 		}
 
 		for _, policy := range outputPolicies.Policies {
-			// only fetch user created policies
-			if aws.ToString(policy.Arn)[:20] != "arn:aws:iam::aws:pol" {
-				tags := make([]Tag, 0)
-				for {
-					configTags.PolicyArn = policy.Arn
-					outputPolicyTags, err := iamClient.ListPolicyTags(ctx, &configTags)
-					if err != nil {
-						return resources, err
-					}
-
-					for _, t := range outputPolicyTags.Tags {
-						tags = append(tags, Tag{
-							Key:   *t.Key,
-							Value: *t.Value,
-						})
-					}
-
-					if aws.ToString(outputPolicyTags.Marker) == "" {
-						break
-					}
-
-					configTags.Marker = outputPolicyTags.Marker
+			tags := make([]Tag, 0)
+			for {
+				configTags.PolicyArn = policy.Arn
+				outputPolicyTags, err := iamClient.ListPolicyTags(ctx, &configTags)
+				if err != nil {
+					return resources, err
 				}
 
-				resources = append(resources, Resource{
-					Provider:   "AWS",
-					Account:    client.Name,
-					Service:    "IAM Policy",
-					ResourceId: *policy.Arn,
-					Region:     client.AWSClient.Region,
-					Name:       *policy.PolicyName,
-					Cost:       0,
-					CreatedAt:  *policy.CreateDate,
-					Tags:       tags,
-					FetchedAt:  time.Now(),
-					Link:       fmt.Sprintf("https://%s.console.aws.amazon.com/iam/home#/policies/%s", client.AWSClient.Region, *policy.Arn),
-				})
+				for _, t := range outputPolicyTags.Tags {
+					tags = append(tags, Tag{
+						Key:   *t.Key,
+						Value: *t.Value,
+					})
+				}
+
+				if aws.ToString(outputPolicyTags.Marker) == "" {
+					break
+				}
+
+				configTags.Marker = outputPolicyTags.Marker
 			}
+
+			resources = append(resources, Resource{
+				Provider:   "AWS",
+				Account:    client.Name,
+				Service:    "IAM Policy",
+				ResourceId: *policy.Arn,
+				Region:     client.AWSClient.Region,
+				Name:       *policy.PolicyName,
+				Cost:       0,
+				CreatedAt:  *policy.CreateDate,
+				Tags:       tags,
+				FetchedAt:  time.Now(),
+				Link:       fmt.Sprintf("https://%s.console.aws.amazon.com/iam/home#/policies/%s", client.AWSClient.Region, *policy.Arn),
+			})
 		}
 
 		if aws.ToString(outputPolicies.Marker) == "" {


### PR DESCRIPTION
## Problem
Closes #729 

## Solution
Saved up a lot of pre-created default policies (adding 0 to the cloud costs) and their rows from the inventory.
ANDDD
Performance gains by an approx **10x** 🚀 
How:
- Before: Querying atleast 1000 predefined policies from 22 AWS zones 
- After: Querying only user created policies (realistically worst case 100? ) from 22 AWS zones

### Before
![Screenshot_2023-04-17-19-03-32_4920x1920](https://user-images.githubusercontent.com/55556994/232503604-3e0e442c-88b0-436a-b42d-3f51d8e9f191.png)

### After
![Screenshot_2023-04-17-19-11-31_4920x1920](https://user-images.githubusercontent.com/55556994/232503635-09199514-5409-437f-86f5-bc96c6fef4cc.png)

## Notes
~~However, we still iterate through the 1000 something extra policies so there definites is a scope for efficiency and performance gains!~~
10x gains lesssgooo!

## Checklist

- [x] Code follows the <a href="https://github.com/tailwarden/komiser/blob/master/CONTRIBUTING.md">contributing</a> guidelines
- [x] Changes have been thoroughly tested
- [ ] <a href="https://github.com/tailwarden/docs.komiser.io">Documentation</a> has been updated, if necessary
- [x] Any dependencies have been added to the project, if necessary
