### PR TITLE
Feature/522 support aws ec2 vpc endpoint

### DIFF
--- a/providers/aws/aws.go
+++ b/providers/aws/aws.go
@@ -79,6 +79,7 @@ func listOfSupportedServices() []providers.FetchDataFunction {
 		ec2.KeyPairs,
 		ec2.PlacementGroups,
 		systemsmanager.MaintenanceWindows,
+		ec2.VpcEndpoints,
 	}
 }
 

--- a/providers/aws/aws.go
+++ b/providers/aws/aws.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"strings"
 
-	"github.com/sirupsen/logrus"
 	log "github.com/sirupsen/logrus"
 
 	"github.com/tailwarden/komiser/providers"
@@ -100,7 +99,7 @@ func FetchResources(ctx context.Context, client providers.ProviderClient, region
 				for _, resource := range resources {
 					_, err = db.NewInsert().Model(&resource).On("CONFLICT (resource_id) DO UPDATE").Set("cost = EXCLUDED.cost").Exec(context.Background())
 					if err != nil {
-						logrus.WithError(err).Errorf("db trigger failed")
+						log.WithError(err).Errorf("db trigger failed")
 					}
 				}
 				if telemetry {

--- a/providers/aws/ec2/vpc-endpoints.go
+++ b/providers/aws/ec2/vpc-endpoints.go
@@ -1,0 +1,78 @@
+package ec2
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	log "github.com/sirupsen/logrus"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/ec2"
+	. "github.com/tailwarden/komiser/models"
+	. "github.com/tailwarden/komiser/providers"
+)
+
+func VpcEndpoints(ctx context.Context, client ProviderClient) ([]Resource, error) {
+	var config ec2.DescribeVpcEndpointsInput
+	resources := make([]Resource, 0)
+	ec2Client := ec2.NewFromConfig(*client.AWSClient)
+
+	for {
+		output, err := ec2Client.DescribeVpcEndpoints(ctx, &config)
+		if err != nil {
+			return resources, err
+		}
+
+		for _, vpcEndpoint := range output.VpcEndpoints {
+			name := ""
+			tags := make([]Tag, 0)
+			for _, tag := range vpcEndpoint.Tags {
+				if *tag.Key == "Name" {
+					name = *tag.Value
+				}
+				tags = append(tags, Tag{
+					Key:   *tag.Key,
+					Value: *tag.Value,
+				})
+			}
+
+			resources = append(resources, Resource{
+				Provider:   "AWS",
+				Account:    client.Name,
+				Service:    "VPC Endpoint",
+				Region:     client.AWSClient.Region,
+				Name:       name,
+				ResourceId: *vpcEndpoint.VpcEndpointId,
+				CreatedAt:  *vpcEndpoint.CreationTimestamp,
+				FetchedAt:  time.Now(),
+				Cost:       0,
+				Tags:       tags,
+				Link: fmt.Sprintf(
+					"https:/%s.console.aws.amazon.com/vpc/home?region=%s#EndpointDetails:vpcEndpointId=%s",
+					client.AWSClient.Region,
+					client.AWSClient.Region,
+					*vpcEndpoint.VpcEndpointId,
+				),
+				Metadata: map[string]string{
+					"VpcEndpointType": string(vpcEndpoint.VpcEndpointType),
+					"ServiceName":     string(*vpcEndpoint.ServiceName),
+				},
+			})
+		}
+
+		if aws.ToString(output.NextToken) == "" {
+			break
+		}
+
+		config.NextToken = output.NextToken
+	}
+	log.WithFields(log.Fields{
+		"provider":  "AWS",
+		"account":   client.Name,
+		"region":    client.AWSClient.Region,
+		"service":   "VPC Endpoint",
+		"resources": len(resources),
+	}).Info("Fetched resources")
+	return resources, nil
+}


### PR DESCRIPTION
## Problem

Supporting AWS EC2 VPC Endpoint

## Solution

This solution adds support for VPC Endpoint using the [aws-sdk-go-v2](https://github.com/aws/aws-sdk-go-v2) that supports VPC Endpoint.

## Changes Made

- Adds VPC Endpoint support to the AWS Provider

## How to Test

The changes do not require any custom configuration. The AWS Provider has been added to the project and the configuration steps are here in the documentation.

To populate data from AWS, you might need to create a VPC endpoint attached to a VPC network.

## Screenshots

[Include screenshots, if relevant, to help reviewers understand the changes you made.]

## Notes

[Any additional notes or information that you would like to share with the reviewers.]

## Checklist

- [x] Code follows the <a href="https://github.com/tailwarden/komiser/blob/master/CONTRIBUTING.md">contributing</a> guidelines
- [x] Changes have been thoroughly tested
- [ ] <a href="https://github.com/tailwarden/docs.komiser.io">Documentation</a> has been updated, if necessary
- [x] Any dependencies have been added to the project, if necessary

## Reviewers

@jakepage91 @mlabouardy

