### PR TITLE
EC2 Elastic IP panic fix

### DIFF
--- a/providers/aws/ec2/elastic_ips.go
+++ b/providers/aws/ec2/elastic_ips.go
@@ -64,15 +64,24 @@ func ElasticIps(ctx context.Context, client ProviderClient) ([]Resource, error) 
 			} else {
 				if len(resourceConfig.BaseConfigurationItems) > 0 {
 					creationTime := resourceConfig.BaseConfigurationItems[0].ResourceCreationTime
-					hoursSinceCreation := hoursSince(*creationTime)
+					if creationTime != nil {
+						hoursSinceCreation := hoursSince(*creationTime)
 
-					hourlyCost := 0.005
+						hourlyCost := 0.005
 
-					if elasticIps.InstanceId != nil {
-						cost = 0
+						if elasticIps.InstanceId != nil {
+							cost = 0
+						} else {
+							cost = hourlyCost * hoursSinceCreation
+						}
 					} else {
-						cost = hourlyCost * hoursSinceCreation
+						cost = 0
+						log.WithFields(log.Fields{
+							"service":  "Elastic IP",
+							"provider": "AWS",
+						}).Warn("Cost couldn't be calculated because the creationTime returned by resource config is nil")
 					}
+
 				}
 			}
 

--- a/providers/aws/ec2/elastic_ips.go
+++ b/providers/aws/ec2/elastic_ips.go
@@ -79,7 +79,7 @@ func ElasticIps(ctx context.Context, client ProviderClient) ([]Resource, error) 
 						log.WithFields(log.Fields{
 							"service":  "Elastic IP",
 							"provider": "AWS",
-						}).Warn("Cost couldn't be calculated because the creationTime returned by resource config is nil")
+						}).Error("Cost couldn't be calculated because the creationTime returned by resource config is nil")
 					}
 
 				}


### PR DESCRIPTION
## Problem

Elastic IP run into this nil panic because of an unhandled pointer dereference.

```
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x0 pc=0x1e22669]

goroutine 16 [running]:
github.com/tailwarden/komiser/providers/aws/ec2.ElasticIps({0x3564dd0, 0xc000126048}, {0xc000ff5d40, 0x0, {0x0, 0x0}, 0x0, 0x0, 0x0, 0x0, ...})
        /home/runner/work/komiser/komiser/providers/aws/ec2/elastic_ips.go:67 +0x449
github.com/tailwarden/komiser/providers/aws.FetchResources({_, _}, {0xc000ff5d40, 0x0, {0x0, 0x0}, 0x0, 0x0, 0x0, 0x0, ...}, ...)
        /home/runner/work/komiser/komiser/providers/aws/aws.go:96 +0x555
github.com/tailwarden/komiser/internal.fetchResources.func1({0x3564dd0?, 0xc000126048?}, {0xc000ff5d40, 0x0, {0x0, 0x0}, 0x0, 0x0, 0x0, 0x0, ...}, ...)
        /home/runner/work/komiser/komiser/internal/internal.go:270 +0x1e9
created by github.com/tailwarden/komiser/internal.fetchResources
        /home/runner/work/komiser/komiser/internal/internal.go:264 +0x109e
```

## Solution

Handle the pointer dereference with an error in cause of nil value.

