### PR TITLE
Estimate GCP VM pricing

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,5 @@ bin
 dist/
 
 *.go-e
+.idea
+vendor

--- a/go.mod
+++ b/go.mod
@@ -4,6 +4,7 @@ go 1.20
 
 require (
 	cloud.google.com/go/bigquery v1.49.0
+	cloud.google.com/go/billing v1.13.0
 	cloud.google.com/go/compute v1.19.0
 	cloud.google.com/go/container v1.16.0
 	cloud.google.com/go/kms v1.10.0
@@ -79,6 +80,7 @@ require (
 
 require (
 	cloud.google.com/go/longrunning v0.4.1 // indirect
+	github.com/PumpkinSeed/gcpcomputepricing v0.0.0-20230505154127-b80654087ea6 // indirect
 	github.com/apache/arrow/go/v11 v11.0.0 // indirect
 )
 

--- a/go.sum
+++ b/go.sum
@@ -3,6 +3,8 @@ cloud.google.com/go v0.110.0 h1:Zc8gqp3+a9/Eyph2KDmcGaPtbKRIoqq4YTlL4NMD0Ys=
 cloud.google.com/go v0.110.0/go.mod h1:SJnCLqQ0FCFGSZMUNUf84MV3Aia54kn7pi8st7tMzaY=
 cloud.google.com/go/bigquery v1.49.0 h1:yE+MpeFaRX9L3rYJrIxl1zCDnTU2kyTA2FkrFd6kVT8=
 cloud.google.com/go/bigquery v1.49.0/go.mod h1:Sv8hMmTFFYBlt/ftw2uN6dFdQPzBlREY9yBh7Oy7/4Q=
+cloud.google.com/go/billing v1.13.0 h1:JYj28UYF5w6VBAh0gQYlgHJ/OD1oA+JgW29YZQU+UHM=
+cloud.google.com/go/billing v1.13.0/go.mod h1:7kB2W9Xf98hP9Sr12KfECgfGclsH3CQR0R08tnRlRbc=
 cloud.google.com/go/certificatemanager v1.6.0 h1:5C5UWeSt8Jkgp7OWn2rCkLmYurar/vIWIoSQ2+LaTOc=
 cloud.google.com/go/certificatemanager v1.6.0/go.mod h1:3Hh64rCKjRAX8dXgRAyOcY5vQ/fE1sh8o+Mdd6KPgY8=
 cloud.google.com/go/compute v1.19.0 h1:+9zda3WGgW1ZSTlVppLCYFIr48Pa35q1uG2N1itbCEQ=
@@ -49,6 +51,8 @@ github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03
 github.com/BurntSushi/toml v1.2.1 h1:9F2/+DoOYIOksmaJFPw1tGFy1eDnIJXg+UHjuD8lTak=
 github.com/BurntSushi/toml v1.2.1/go.mod h1:CxXYINrC8qIiEnFrOxCa7Jy5BFHlXnUU2pbicEuybxQ=
 github.com/JohnCGriffin/overflow v0.0.0-20211019200055-46fa312c352c h1:RGWPOewvKIROun94nF7v2cua9qP+thov/7M50KEoeSU=
+github.com/PumpkinSeed/gcpcomputepricing v0.0.0-20230505154127-b80654087ea6 h1:P/qMU6e+zNXKeJlqE/0Wi3ccdUIxQKOQmNsI+vgon98=
+github.com/PumpkinSeed/gcpcomputepricing v0.0.0-20230505154127-b80654087ea6/go.mod h1:4+uknxSoYWLLXeh2QkNsDXgBEge/6LtPgk0kxsZ4cO0=
 github.com/andybalholm/brotli v1.0.4 h1:V7DdXeJtZscaqfNuAdSRuRFzuiKlHSC/Zh3zl9qY3JY=
 github.com/andybalholm/brotli v1.0.4/go.mod h1:fO7iG3H7G2nSZ7m0zPUDn85XEX2GTukHGRSepvi9Eig=
 github.com/apache/arrow/go/v11 v11.0.0 h1:hqauxvFQxww+0mEU/2XHG6LT7eZternCZq+A5Yly2uM=

--- a/providers/gcp/compute/disks.go
+++ b/providers/gcp/compute/disks.go
@@ -13,7 +13,7 @@ import (
 	"google.golang.org/api/option"
 
 	compute "cloud.google.com/go/compute/apiv1"
-	computepb "cloud.google.com/go/compute/apiv1/computepb"
+	"cloud.google.com/go/compute/apiv1/computepb"
 )
 
 func Disks(ctx context.Context, client providers.ProviderClient) ([]models.Resource, error) {

--- a/providers/gcp/compute/instances_test.go
+++ b/providers/gcp/compute/instances_test.go
@@ -1,0 +1,30 @@
+package compute
+
+import (
+	"context"
+	"fmt"
+	"io/ioutil"
+	"testing"
+
+	"github.com/tailwarden/komiser/providers"
+	"golang.org/x/oauth2/google"
+)
+
+func TestInstances(t *testing.T) {
+	data, err := ioutil.ReadFile("")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	creds, err := google.CredentialsFromJSON(context.Background(), data, "https://www.googleapis.com/auth/cloud-platform")
+	if err != nil {
+		t.Fatal(err)
+	}
+	resource, err := Instances(context.Background(), providers.ProviderClient{
+		GCPClient: &providers.GCPClient{Credentials: creds},
+	})
+	if err != nil {
+		t.Error(err)
+	}
+	fmt.Println(resource)
+}


### PR DESCRIPTION
The price calculation of the GCP VM instances are a very complex thing, but it can be broken down to smaller pieces. The first piece is to calculate the price of the machine type what the instance originated. This solution get the actual pricing from the `https://www.gstatic.com/cloud-site-ux/pricing/data/gcp-compute.json` and start the calculation with the number of CPUs and memory under a certain machine type.