### PR TITLE
docs: fix Broken links in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,9 +39,9 @@ brew install komiser
 <!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE -->
 **Table of Contents**
 
-- [What is Komiser?](#what-is-komiser)
+- [What is Komiser?](#what-is-komiser-)
   - [Who is using it?](#who-is-using-it)
-- [Getting started](#getting-started)
+- [Getting started](#getting-started-)
   - [Download](#download)
   - [Installation on AWS](#installation-on-aws)
     - [Connect Komiser CLI to your AWS account.](#connect-komiser-cli-to-your-aws-account)
@@ -54,12 +54,12 @@ brew install komiser
   - [Installation on Linode](#installation-on-linode)
   - [Installation on Tencent](#installation-on-tencent-cloud)
   - [Installation on Scaleway](#installation-on-scaleway)
-- [Documentation](#documentation)
+- [Documentation](#documentation-)
   - [Jump right in:](#jump-right-in)
-- [Bugs and feature requests](#bugs-and-feature-requests)
-- [Roadmap and Contributing](#roadmap-and-contributing)
-- [Users](#users)
-- [Versioning](#versioning)
+- [Bugs and feature requests](#bugs-and-feature-requests-)
+- [Roadmap and Contributing](#roadmap-and-contributing-%EF%B8%8F)
+- [Users](#users-)
+- [Versioning](#versioning-)
 
 <!-- END doctoc generated TOC please keep comment here to allow auto update -->
 


### PR DESCRIPTION
## Problem

Broken links in readme

## Solution

Add hyphens and encoded-emoji wherever necessary.

## Changes Made

Added those characters. Only linking "Roadmap and Contributing" required encoded emoji, others worked just with a hyphen

## How to Test

Click click click

## Checklist

- [x] Code follows the <a href="https://github.com/tailwarden/komiser/blob/master/CONTRIBUTING.md">contributing</a> guidelines
- [x] Changes have been thoroughly tested
- [ ] <a href="https://github.com/tailwarden/docs.komiser.io">Documentation</a> has been updated, if necessary
- [ ] Any dependencies have been added to the project, if necessary
