### PR TITLE
feat(rds): add RDS db proxy endpoint capabilities

### DIFF
--- a/providers/aws/aws.go
+++ b/providers/aws/aws.go
@@ -64,6 +64,7 @@ func listOfSupportedServices() []providers.FetchDataFunction {
 		rds.Clusters,
 		rds.Instances,
 		rds.Snapshots,
+		rds.ProxyEndpoints,
 		elb.LoadBalancers,
 		efs.ElasticFileStorage,
 		apigateway.Apis,

--- a/providers/aws/rds/db_proxy_endpoints.go
+++ b/providers/aws/rds/db_proxy_endpoints.go
@@ -4,12 +4,11 @@ import (
 	"context"
 	"fmt"
 	"github.com/aws/aws-sdk-go-v2/aws"
-	"time"
-
 	"github.com/aws/aws-sdk-go-v2/service/rds"
 	log "github.com/sirupsen/logrus"
 	"github.com/tailwarden/komiser/models"
 	"github.com/tailwarden/komiser/providers"
+	"time"
 )
 
 func ProxyEndpoints(ctx context.Context, client providers.ProviderClient) ([]models.Resource, error) {
@@ -22,13 +21,42 @@ func ProxyEndpoints(ctx context.Context, client providers.ProviderClient) ([]mod
 	for {
 		output, err := rdsClient.DescribeDBProxyEndpoints(ctx, &config)
 		if err != nil {
-			return resources, err
+			return resources, fmt.Errorf("error describing DB proxy endpoints: %w", err)
 		}
 
 		for _, endpoint := range output.DBProxyEndpoints {
-			tags := make([]models.Tag, 0)
-			//TODO (siddarthkay) : double check on tag retrieval
+
+			if endpoint.DBProxyEndpointName == nil {
+				log.Warn("DBProxyEndpointName is nil")
+				continue
+			}
+
+			if endpoint.DBProxyEndpointArn == nil {
+				log.Warn("DBProxyEndpointArn is nil")
+				continue
+			}
+
 			_endpointName := *endpoint.DBProxyEndpointName
+
+			// Fetch tags
+			tagConfig := rds.ListTagsForResourceInput{
+				ResourceName: endpoint.DBProxyEndpointArn,
+			}
+
+			tagOutput, err := rdsClient.ListTagsForResource(ctx, &tagConfig)
+			if err != nil {
+				return resources, fmt.Errorf("error listing tags for resource %s: %w", *endpoint.DBProxyEndpointArn, err)
+			}
+
+			tags := make([]models.Tag, 0)
+			for _, tag := range tagOutput.TagList {
+				if tag.Key != nil && tag.Value != nil {
+					tags = append(tags, models.Tag{
+						Key:   *tag.Key,
+						Value: *tag.Value,
+					})
+				}
+			}
 
 			resources = append(resources, models.Resource{
 				Provider:   "AWS",
@@ -39,7 +67,7 @@ func ProxyEndpoints(ctx context.Context, client providers.ProviderClient) ([]mod
 				Name:       _endpointName,
 				FetchedAt:  time.Now(),
 				Tags:       tags,
-				Link:       fmt.Sprintf("https://%s.console.aws.amazon.com/rds/home?region=%s#dbproxy:endpoint=%s", client.AWSClient.Region, client.AWSClient.Region, *endpoint.DBProxyEndpointName),
+				Link:       fmt.Sprintf("https://%s.console.aws.amazon.com/rds/home?region=%s#db-proxy-details:id=%s", client.AWSClient.Region, client.AWSClient.Region, *endpoint.DBProxyEndpointName),
 			})
 		}
 

--- a/providers/aws/rds/db_proxy_endpoints.go
+++ b/providers/aws/rds/db_proxy_endpoints.go
@@ -1,0 +1,62 @@
+package rds
+
+import (
+	"context"
+	"fmt"
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"time"
+
+	"github.com/aws/aws-sdk-go-v2/service/rds"
+	log "github.com/sirupsen/logrus"
+	"github.com/tailwarden/komiser/models"
+	"github.com/tailwarden/komiser/providers"
+)
+
+func ProxyEndpoints(ctx context.Context, client providers.ProviderClient) ([]models.Resource, error) {
+	config := rds.DescribeDBProxyEndpointsInput{
+		MaxRecords: aws.Int32(100),
+	}
+	resources := make([]models.Resource, 0)
+	rdsClient := rds.NewFromConfig(*client.AWSClient)
+
+	for {
+		output, err := rdsClient.DescribeDBProxyEndpoints(ctx, &config)
+		if err != nil {
+			return resources, err
+		}
+
+		for _, endpoint := range output.DBProxyEndpoints {
+			tags := make([]models.Tag, 0)
+			//TODO (siddarthkay) : double check on tag retrieval
+			_endpointName := *endpoint.DBProxyEndpointName
+
+			resources = append(resources, models.Resource{
+				Provider:   "AWS",
+				Account:    client.Name,
+				Service:    "RDS DB Proxy Endpoint",
+				Region:     client.AWSClient.Region,
+				ResourceId: *endpoint.DBProxyEndpointArn,
+				Name:       _endpointName,
+				FetchedAt:  time.Now(),
+				Tags:       tags,
+				Link:       fmt.Sprintf("https://%s.console.aws.amazon.com/rds/home?region=%s#dbproxy:endpoint=%s", client.AWSClient.Region, client.AWSClient.Region, *endpoint.DBProxyEndpointName),
+			})
+		}
+
+		if output.Marker == nil || *output.Marker == "" {
+			break
+		}
+
+		config.Marker = output.Marker
+	}
+
+	log.WithFields(log.Fields{
+		"provider":  "AWS",
+		"account":   client.Name,
+		"region":    client.AWSClient.Region,
+		"service":   "RDS DB Proxy Endpoint",
+		"resources": len(resources),
+	}).Info("Fetched resources")
+
+	return resources, nil
+}


### PR DESCRIPTION
## Problem

Ability to view RDS Db Proxy endpoint inputs does not exist.

## Solution

This PR adds a new `db_proxy_endpoints.go` file which queries the AWS Go SDK and implements support for returning RDS ProxyEndpoints.
An entry has also been made to `aws.go` to make sure `rds.ProxyEndpoints` is included

## Changes Made

fixes #565

## How to Test

Apply filter in Dashboard:
- Cloud Provider is AWS
- Cloud Service is RDS DB Proxy endpoint

and you should be able to see RDS ProxyEndpoint resources.

## Screenshots

WIP


## Checklist

- [x] Code follows the <a href="https://github.com/tailwarden/komiser/blob/master/CONTRIBUTING.md">contributing</a> guidelines
- [x] Changes have been thoroughly tested
- [ ] <a href="https://github.com/tailwarden/docs.komiser.io">Documentation</a> has been updated, if necessary
- [ ] Any dependencies have been added to the project, if necessary

## Reviewers


