### PR TITLE
add account name for AWS ec2 keypair inventories

### DIFF
--- a/providers/aws/ec2/keypair.go
+++ b/providers/aws/ec2/keypair.go
@@ -34,6 +34,7 @@ func KeyPairs(ctx context.Context, client providers.ProviderClient) ([]models.Re
 
 		resources = append(resources, models.Resource{
 			Provider:   "AWS",
+			Account:    client.Name,
 			Service:    "EC2 KeyPair",
 			ResourceId: aws.ToString(keypair.KeyPairId),
 			Region:     client.AWSClient.Region,


### PR DESCRIPTION
Fix for https://github.com/tailwarden/komiser/issues/804