### PR TITLE
fix: Dockerfile MAINTAINER label

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@ ARG TARGETPLATFORM
 ARG BUILDPLATFORM
 ARG SEGMENT_WRITE_KEY
 ARG VERSION
-MAINTAINER mlabouardy <mohamed@tailwarden.com>
+LABEL MAINTAINER="mlabouardy <mohamed@tailwarden.com>"
 
 RUN echo "Running on $BUILDPLATFORM, building for $TARGETPLATFORM" > /log
 


### PR DESCRIPTION
## Problem
As Usage of MAINTAINER is depricated in Dockerfile

## Solution
Used
LABEL to define maintainers information

## Changes Made

- [List the changes you made in this pull request, including any new features or bug fixes.]

## How to Test

[Provide instructions on how to test the changes you made, including any relevant details like configuration steps or data to be used for testing.]

## Screenshots

[Include screenshots, if relevant, to help reviewers understand the changes you made.]

## Notes

[Any additional notes or information that you would like to share with the reviewers.]

## Checklist

- [ ] Code follows the <a href="https://github.com/tailwarden/komiser/blob/master/CONTRIBUTING.md">contributing</a> guidelines
- [ ] Changes have been thoroughly tested
- [ ] <a href="https://github.com/tailwarden/docs.komiser.io">Documentation</a> has been updated, if necessary
- [ ] Any dependencies have been added to the project, if necessary

## Reviewers

@[username of the reviewer]

