### PR TITLE
feat(aws): estimate aws cloudwatch costs

### DIFF
--- a/providers/aws/cloudwatch/alarms.go
+++ b/providers/aws/cloudwatch/alarms.go
@@ -2,7 +2,11 @@ package cloudwatch
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
+	"github.com/aws/aws-sdk-go-v2/service/pricing"
+	"github.com/aws/aws-sdk-go-v2/service/pricing/types"
+	"strconv"
 	"time"
 
 	log "github.com/sirupsen/logrus"
@@ -13,9 +17,21 @@ import (
 	. "github.com/tailwarden/komiser/providers"
 )
 
+const (
+	RateCode             = "JRTCKXETXF.6YS6EN2CT7"
+	AverageHoursPerMonth = 730
+)
+
 func Alarms(ctx context.Context, client ProviderClient) ([]Resource, error) {
 	resources := make([]Resource, 0)
 	var config cloudwatch.DescribeAlarmsInput
+	// This code temporarily changes the region to "us-east-1" and creates a new Pricing client
+	// then changes the region back to what it was before.
+	// This is necessary because the Pricing client needs to operate in the "us-east-1" region
+	oldRegion := client.AWSClient.Region
+	client.AWSClient.Region = "us-east-1"
+	pricingClient := pricing.NewFromConfig(*client.AWSClient)
+	client.AWSClient.Region = oldRegion
 	cloudWatchClient := cloudwatch.NewFromConfig(*client.AWSClient)
 	for {
 		output, err := cloudWatchClient.DescribeAlarms(ctx, &config)
@@ -39,6 +55,33 @@ func Alarms(ctx context.Context, client ProviderClient) ([]Resource, error) {
 				}
 			}
 
+			pricingOutput, err := pricingClient.GetProducts(ctx, &pricing.GetProductsInput{
+				ServiceCode: aws.String("AmazonCloudWatch"),
+				Filters: []types.Filter{
+					{
+						Field: aws.String("regionCode"),
+						Value: aws.String(client.AWSClient.Region),
+						Type:  types.FilterTypeTermMatch,
+					},
+					{
+						Field: aws.String("group"),
+						Value: aws.String("Alarm"),
+						Type:  types.FilterTypeTermMatch,
+					},
+				},
+				MaxResults: aws.Int32(1),
+			})
+			if err != nil {
+				log.Printf("ERROR: Couldn't fetch pricing info for alarm %s: %v", *alarm.AlarmName, err)
+				continue
+			}
+
+			costPerMonth, err := calculateCostPerMonth(pricingOutput)
+			if err != nil {
+				log.Printf("ERROR: Failed to calculate cost per month: %v", err)
+				continue
+			}
+
 			resources = append(resources, Resource{
 				Provider:   "AWS",
 				Account:    client.Name,
@@ -46,7 +89,7 @@ func Alarms(ctx context.Context, client ProviderClient) ([]Resource, error) {
 				ResourceId: *alarm.AlarmArn,
 				Region:     client.AWSClient.Region,
 				Name:       *alarm.AlarmName,
-				Cost:       0,
+				Cost:       costPerMonth,
 				Tags:       tags,
 				FetchedAt:  time.Now(),
 				Link:       fmt.Sprintf("https://%s.console.aws.amazon.com/cloudwatch/home?region=%s#alarmsV2:alarm/%s", client.AWSClient.Region, client.AWSClient.Region, *alarm.AlarmName),
@@ -67,4 +110,38 @@ func Alarms(ctx context.Context, client ProviderClient) ([]Resource, error) {
 	}).Info("Fetched resources")
 
 	return resources, nil
+}
+
+func calculateCostPerMonth(pricingOutput *pricing.GetProductsOutput) (float64, error) {
+	costPerMonth := 0.0
+
+	if pricingOutput != nil && len(pricingOutput.PriceList) > 0 {
+		var priceList interface{}
+		err := json.Unmarshal([]byte(pricingOutput.PriceList[0]), &priceList)
+		if err != nil {
+			return 0, fmt.Errorf("failed to unmarshal JSON: %w", err)
+		}
+
+		priceListMap := priceList.(map[string]interface{})
+		if onDemand, ok := priceListMap["terms"].(map[string]interface{})["OnDemand"]; ok {
+			for _, details := range onDemand.(map[string]interface{}) {
+				if priceDetails, ok := details.(map[string]interface{})["priceDimensions"].(map[string]interface{}); ok {
+					for _, price := range priceDetails {
+						rateCode := price.(map[string]interface{})["rateCode"].(string)
+						if rateCode == RateCode {
+							usdPrice := price.(map[string]interface{})["pricePerUnit"].(map[string]interface{})["USD"].(string)
+							cost, err := strconv.ParseFloat(usdPrice, 64)
+							if err != nil {
+								return 0, fmt.Errorf("failed to parse cost per month: %w", err)
+							}
+							costPerMonth = cost * AverageHoursPerMonth
+							break
+						}
+					}
+				}
+			}
+		}
+	}
+
+	return costPerMonth, nil
 }


### PR DESCRIPTION
## Problem

Ability to calculate and view AWS Cloudwatch cost does not exist.

## Solution

This PR adds a new `cloudwatch.go` file which queries the AWS v2 Go SDK and implements support for calculating AWS cloudwatch alarm costs.
An entry has also been made to `aws.go` to make sure `ec2.CloudWatchAlarms` is included.

## Changes Made

fixes #415 

## How to Test

WIP

## Screenshots

WIP

## Checklist

- [x] Code follows the <a href="https://github.com/tailwarden/komiser/blob/master/CONTRIBUTING.md">contributing</a> guidelines
- [x] Changes have been thoroughly tested
- [ ] <a href="https://github.com/tailwarden/docs.komiser.io">Documentation</a> has been updated, if necessary
- [ ] Any dependencies have been added to the project, if necessary

## Reviewers
@mlabouardy 

