### PR TITLE
moved type interface AutoScalingGroupClient from the file autoscaling…

### DIFF
--- a/providers/aws/ec2/autoscaling_groups.go
+++ b/providers/aws/ec2/autoscaling_groups.go
@@ -89,3 +89,11 @@ func (d ASGDiscoverer) Discover() ([]Resource, error) {
 	}).Info("Fetched resources")
 	return resources, nil
 }
+
+type AutoScalingGroupClient interface {
+	DescribeAutoScalingGroups(
+		ctx context.Context,
+		params *autoscaling.DescribeAutoScalingGroupsInput,
+		optFns ...func(*autoscaling.Options),
+	) (*autoscaling.DescribeAutoScalingGroupsOutput, error)
+}

--- a/providers/aws/ec2/autoscaling_groups_client.go
+++ b/providers/aws/ec2/autoscaling_groups_client.go
@@ -5,11 +5,3 @@ import (
 
 	"github.com/aws/aws-sdk-go-v2/service/autoscaling"
 )
-
-type AutoScalingGroupClient interface {
-	DescribeAutoScalingGroups(
-		ctx context.Context,
-		params *autoscaling.DescribeAutoScalingGroupsInput,
-		optFns ...func(*autoscaling.Options),
-	) (*autoscaling.DescribeAutoScalingGroupsOutput, error)
-}


### PR DESCRIPTION
…_groups_client.go to autoscaling_groups.go.

## Problem

I saw a post in the issues, https://github.com/tailwarden/komiser/issues/872, that said that having the type interface "AutoScalingGroupClient" in the "autoscaling_groups_client.go" file was a bad approach.

## Solution

My solution was to move the type interface "AutoScalingGroupClient" from the file "autoscaling_groups_client.go" to the file "autoscaling_groups.go".

## Changes Made

I moved a type interface.

## Checklist

- [ ] Code follows the <a href="https://github.com/tailwarden/komiser/blob/master/CONTRIBUTING.md">contributing</a> guidelines
- [ ] Changes have been thoroughly tested
- [ ] <a href="https://github.com/tailwarden/docs.komiser.io">Documentation</a> has been updated, if necessary
- [ ] Any dependencies have been added to the project, if necessary

## Reviewers

@[username of the reviewer]

