### PR TITLE
Optimise CI: Cache Go Builds

### DIFF
--- a/.github/workflows/build_test_pr.yml
+++ b/.github/workflows/build_test_pr.yml
@@ -33,6 +33,8 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v4
         with:
+          cache: true
+          cache-dependency-path: go.sum
           go-version: 1.20.2
 
       # FIXME: https://github.com/golangci/golangci-lint-action/issues/677

--- a/Makefile
+++ b/Makefile
@@ -36,7 +36,6 @@ package:
 test:
 	go test -v $(go list ./... | grep -v /dashboard/)
 
-
 ## version: Show version.
 version:
 	@echo version: $(VERSION)

--- a/Makefile
+++ b/Makefile
@@ -36,6 +36,7 @@ package:
 test:
 	go test -v $(go list ./... | grep -v /dashboard/)
 
+
 ## version: Show version.
 version:
 	@echo version: $(VERSION)


### PR DESCRIPTION
## Problem
Closes #884
### Before:
![image](https://github.com/tailwarden/komiser/assets/55556994/54434d69-82c3-4eae-84d8-51a503714c54)

### After:
![Screenshot_2023-07-08-02-58-16_1920x1080](https://github.com/tailwarden/komiser/assets/55556994/c9cbc56d-3d8a-41bd-a9b1-ac7b378d464c)

Difference in time after the first run is massive thanks to the omnipresent **CACHING**

## Solution
We start caching test outputs now to prevent repeated runnings when nothing has changed!
This, although, does not optimise the core `make test` command, it leverages the caching ability of github actions' setup-go package to help us

## Checklist

- [x] Code follows the <a href="https://github.com/tailwarden/komiser/blob/master/CONTRIBUTING.md">contributing</a> guidelines
- [x] Changes have been thoroughly tested
- [x] <a href="https://github.com/tailwarden/docs.komiser.io">Documentation</a> has been updated, if necessary
- [x] Any dependencies have been added to the project, if necessary

