### PR TITLE
feat: collect aws rds auto backup resources

### DIFF
--- a/providers/aws/aws.go
+++ b/providers/aws/aws.go
@@ -67,6 +67,7 @@ func listOfSupportedServices() []providers.FetchDataFunction {
 		rds.Snapshots,
 		rds.ClusterSnapshots,
 		rds.ProxyEndpoints,
+		rds.AutoBackups,
 		elb.LoadBalancers,
 		efs.ElasticFileStorage,
 		apigateway.Apis,

--- a/providers/aws/rds/auto_backups.go
+++ b/providers/aws/rds/auto_backups.go
@@ -1,0 +1,56 @@
+package rds
+
+import (
+	"context"
+	"fmt"
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"time"
+
+	"github.com/aws/aws-sdk-go-v2/service/rds"
+	log "github.com/sirupsen/logrus"
+	"github.com/tailwarden/komiser/models"
+	"github.com/tailwarden/komiser/providers"
+)
+
+func AutoBackups(ctx context.Context, client providers.ProviderClient) ([]models.Resource, error) {
+	var config rds.DescribeDBInstanceAutomatedBackupsInput
+	resources := make([]models.Resource, 0)
+	rdsClient := rds.NewFromConfig(*client.AWSClient)
+
+	for {
+		output, err := rdsClient.DescribeDBInstanceAutomatedBackups(ctx, &config)
+		if err != nil {
+			return resources, err
+		}
+
+		for _, backup := range output.DBInstanceAutomatedBackups {
+
+			_backupName := *backup.DBInstanceIdentifier
+
+			resources = append(resources, models.Resource{
+				Provider:   "AWS",
+				Account:    client.Name,
+				Service:    "RDS Backup",
+				Region:     client.AWSClient.Region,
+				ResourceId: *backup.DBInstanceArn,
+				Name:       _backupName,
+				FetchedAt:  time.Now(),
+				Link:       fmt.Sprintf("https:/%s.console.aws.amazon.com/rds/home?region=%s#dbinstance:id=%s", client.AWSClient.Region, client.AWSClient.Region, *backup.DBInstanceIdentifier),
+			})
+		}
+
+		if aws.ToString(output.Marker) == "" {
+			break
+		}
+
+		config.Marker = output.Marker
+	}
+	log.WithFields(log.Fields{
+		"provider":  "AWS",
+		"account":   client.Name,
+		"region":    client.AWSClient.Region,
+		"service":   "RDS Backup",
+		"resources": len(resources),
+	}).Info("Fetched resources")
+	return resources, nil
+}


### PR DESCRIPTION
## Problem

Ability to view RDS Auto Backup Resource does not exist.

## Solution

This PR adds a new `providers/aws/rds/auto_backups.go` file which queries the AWS Go SDK and implements support for returning RDS AutoBackups.
An entry has also been made to `providers/aws/aws.go` to make sure `rds.AutoBackups` is included

## Changes Made

fixes #559 

## How to Test

Apply filter in Dashboard:

- Cloud Provider is AWS
- Cloud Service is RDS Backup
and you should be able to see RDS Backup.

## Screenshots

wip

## Notes

[Any additional notes or information that you would like to share with the reviewers.]

## Checklist

- [x] Code follows the <a href="https://github.com/tailwarden/komiser/blob/master/CONTRIBUTING.md">contributing</a> guidelines
- [x] Changes have been thoroughly tested
- [ ] <a href="https://github.com/tailwarden/docs.komiser.io">Documentation</a> has been updated, if necessary
- [x] Any dependencies have been added to the project, if necessary -> `nope`

## Reviewers

