### PR TITLE
Fixing issue#842: input fields under tags management was unreasonably large

### DIFF
--- a/dashboard/components/input/Input.tsx
+++ b/dashboard/components/input/Input.tsx
@@ -68,7 +68,7 @@ function Input({
         <input
           type={type}
           name={name}
-          className={`peer w-full rounded bg-white px-4 pb-[0.75rem] pt-[1.75rem] text-sm text-black-900 caret-primary outline outline-black-200 focus:outline-2 focus:outline-primary ${
+          className={`peer w-full rounded bg-white px-4 pb-[0.75rem] pt-[1.75rem] text-sm text-black-900 caret-primary outline outline-[0.063rem] outline-black-200 focus:outline-[0.12rem] focus:outline-primary ${
             isValid === false && `outline-error-600 focus:outline-error-600`
           }`}
           placeholder=" "


### PR DESCRIPTION
## Problem
In **Inventory** section, under the **tags** management, input fields in normal state have border size larger than the design suggested.
Issue #842

<img width="460" alt="Issue842" src="https://user-images.githubusercontent.com/10320205/244091087-4ce0fe37-6768-4c96-a173-581ce1a2cb67.png">

## Solution
After inspecting the code, it was found that the outline-width property of the Input Components used in multiple parts of UI was 2px in normal state. For normal state, it should be 1px.

## Changes Made

- Reduced the outline-width of Input Component to 1px in active state.


## Screenshots
Screenshot after the fix
<img width="457" alt="Issue842After" src="https://github.com/tailwarden/komiser/assets/75777457/171863dc-dbdb-449a-900a-a82158d625ed">


## Checklist

- [x] Code follows the <a href="https://github.com/tailwarden/komiser/blob/master/CONTRIBUTING.md">contributing</a> guidelines
- [x] Changes have been thoroughly tested
- [ ] <a href="https://github.com/tailwarden/docs.komiser.io">Documentation</a> has been updated, if necessary
- [ ] Any dependencies have been added to the project, if necessary

## Reviewers

@mlabouardy 

