### PR TITLE
Added support for AWS Load balancer Target Groups

### DIFF
--- a/providers/aws/aws.go
+++ b/providers/aws/aws.go
@@ -69,6 +69,7 @@ func listOfSupportedServices() []providers.FetchDataFunction {
 		rds.ProxyEndpoints,
 		rds.AutoBackups,
 		elb.LoadBalancers,
+		elb.TargetGroups,
 		efs.ElasticFileStorage,
 		apigateway.Apis,
 		elasticache.Clusters,

--- a/providers/aws/elb/targetgroups.go
+++ b/providers/aws/elb/targetgroups.go
@@ -52,7 +52,7 @@ func TargetGroups(ctx context.Context, client ProviderClient) ([]Resource, error
 			Name:       *targetgroup.TargetGroupName,
 			Tags:       tags,
 			FetchedAt:  time.Now(),
-			Link:       fmt.Sprintf("https://%s.console.aws.amazon.com/ec2/home?region=%s#/LoadBalancer:loadBalancerArn=%s", client.AWSClient.Region, client.AWSClient.Region, resourceArn),
+			Link:       fmt.Sprintf("https://%s.console.aws.amazon.com/ec2/home?region=%s#TargetGroup:targetGroupArn=%s", client.AWSClient.Region, client.AWSClient.Region, resourceArn),
 		})
 	}
 

--- a/providers/aws/elb/targetgroups.go
+++ b/providers/aws/elb/targetgroups.go
@@ -1,0 +1,68 @@
+package elb
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	log "github.com/sirupsen/logrus"
+
+	"github.com/aws/aws-sdk-go-v2/service/elasticloadbalancingv2"
+	. "github.com/tailwarden/komiser/models"
+	. "github.com/tailwarden/komiser/providers"
+)
+
+func TargetGroups(ctx context.Context, client ProviderClient) ([]Resource, error) {
+	resources := make([]Resource, 0)
+
+	var config elasticloadbalancingv2.DescribeTargetGroupsInput
+	elbtgClient := elasticloadbalancingv2.NewFromConfig(*client.AWSClient)
+
+	output, err := elbtgClient.DescribeTargetGroups(ctx, &config)
+
+	if err != nil {
+		return resources, err
+	}
+
+	for _, targetgroup := range output.TargetGroups {
+		resourceArn := *targetgroup.TargetGroupArn
+		outputTags, err := elbtgClient.DescribeTags(ctx, &elasticloadbalancingv2.DescribeTagsInput{
+			ResourceArns: []string{resourceArn},
+		})
+		if err != nil {
+			return resources, err
+		}
+
+		tags := make([]Tag, 0)
+		for _, tagDescription := range outputTags.TagDescriptions {
+			for _, tag := range tagDescription.Tags {
+				tags = append(tags, Tag{
+					Key:   *tag.Key,
+					Value: *tag.Value,
+				})
+			}
+		}
+
+		resources = append(resources, Resource{
+			Provider:   "AWS",
+			Account:    client.Name,
+			Service:    "Target Group",
+			ResourceId: resourceArn,
+			Region:     client.AWSClient.Region,
+			Name:       *targetgroup.TargetGroupName,
+			Tags:       tags,
+			FetchedAt:  time.Now(),
+			Link:       fmt.Sprintf("https://%s.console.aws.amazon.com/ec2/home?region=%s#/LoadBalancer:loadBalancerArn=%s", client.AWSClient.Region, client.AWSClient.Region, resourceArn),
+		})
+	}
+
+	log.WithFields(log.Fields{
+		"provider":  "AWS",
+		"account":   client.Name,
+		"region":    client.AWSClient.Region,
+		"service":   "Target Group",
+		"resources": len(resources),
+	}).Info("Fetched resources")
+
+	return resources, nil
+}


### PR DESCRIPTION
## Problem
Add support for AWS ELB Target Groups using Komiser. Closes #540 

## Changes Made

- Added support for getting AWS ELB Target Groups(elb/targetgroups.go)
-  Added `elb.TargetGroups` to `aws.go`

## How to Test

- Make sure your AWS account has Target Groups
- Build and run this branch
- Choose `Target Group` as service filter

## Screenshots
![image](https://github.com/tailwarden/komiser/assets/25551553/f3e69ede-3139-418f-bc20-c4f0922cfb97)


## Checklist

- [x] Code follows the <a href="https://github.com/tailwarden/komiser/blob/master/CONTRIBUTING.md">contributing</a> guidelines
- [x] Changes have been thoroughly tested
- [ ] <a href="https://github.com/tailwarden/docs.komiser.io">Documentation</a> has been updated, if necessary
- [x] Any dependencies have been added to the project, if necessary