### PR TITLE
Removing a / thats breaking the AWS console Load Balancer URL in the UI

### DIFF
--- a/providers/aws/elb/loadbalancers.go
+++ b/providers/aws/elb/loadbalancers.go
@@ -62,7 +62,7 @@ func LoadBalancers(ctx context.Context, client ProviderClient) ([]Resource, erro
 			Tags:       tags,
 			CreatedAt:  *loadbalancer.CreatedTime,
 			FetchedAt:  time.Now(),
-			Link:       fmt.Sprintf("https://%s.console.aws.amazon.com/ec2/home?region=%s#/LoadBalancer:loadBalancerArn=%s", client.AWSClient.Region, client.AWSClient.Region, resourceArn),
+			Link:       fmt.Sprintf("https://%s.console.aws.amazon.com/ec2/home?region=%s#LoadBalancer:loadBalancerArn=%s", client.AWSClient.Region, client.AWSClient.Region, resourceArn),
 		})
 	}
 


### PR DESCRIPTION
## Problem

Solves the issue #914 

## Solution

Remove the / in the URL 

## Changes Made

- Removed a **/** after **#** in the URL

## How to Test

- Build and run the current Develop branch
- Go to Inventory -> All resources -> Filter -> Cloud service -> is -> ELB
- Click one of the Load Balancers and click the link beside the Load Balancer's name

## Screenshots

![image](https://github.com/tailwarden/komiser/assets/25551553/651e8c51-b40c-4a9c-9d20-2f8f233714a7)

## Checklist

- [x] Code follows the <a href="https://github.com/tailwarden/komiser/blob/master/CONTRIBUTING.md">contributing</a> guidelines
- [x] Changes have been thoroughly tested
- [ ] <a href="https://github.com/tailwarden/docs.komiser.io">Documentation</a> has been updated, if necessary
- [x] Any dependencies have been added to the project, if necessary

