### PR TITLE
Added support for AWS ELB Listeners

### DIFF
--- a/providers/aws/elb/loadbalancers.go
+++ b/providers/aws/elb/loadbalancers.go
@@ -23,6 +23,8 @@ func LoadBalancers(ctx context.Context, client ProviderClient) ([]Resource, erro
 		return resources, err
 	}
 
+	var configListeners elasticloadbalancingv2.DescribeListenersInput
+
 	for _, loadbalancer := range output.LoadBalancers {
 		resourceArn := *loadbalancer.LoadBalancerArn
 		outputTags, err := elbClient.DescribeTags(ctx, &elasticloadbalancingv2.DescribeTagsInput{
@@ -64,6 +66,48 @@ func LoadBalancers(ctx context.Context, client ProviderClient) ([]Resource, erro
 			FetchedAt:  time.Now(),
 			Link:       fmt.Sprintf("https://%s.console.aws.amazon.com/ec2/home?region=%s#LoadBalancer:loadBalancerArn=%s", client.AWSClient.Region, client.AWSClient.Region, resourceArn),
 		})
+
+		configListeners.LoadBalancerArn = &resourceArn
+		elblisClient := elasticloadbalancingv2.NewFromConfig(*client.AWSClient)
+
+		output, err := elblisClient.DescribeListeners(ctx, &configListeners)
+		if err != nil {
+			return resources, err
+		}
+
+		for _, listener := range output.Listeners {
+			listenerArn := *listener.ListenerArn
+
+			outputTags, err := elblisClient.DescribeTags(ctx, &elasticloadbalancingv2.DescribeTagsInput{
+				ResourceArns: []string{listenerArn},
+			})
+			if err != nil {
+				return resources, err
+			}
+
+			tags := make([]Tag, 0)
+			for _, tagDescription := range outputTags.TagDescriptions {
+				for _, tag := range tagDescription.Tags {
+					tags = append(tags, Tag{
+						Key:   *tag.Key,
+						Value: *tag.Value,
+					})
+				}
+			}
+
+			resources = append(resources, Resource{
+				Provider:   "AWS",
+				Account:    client.Name,
+				Service:    "ELB Listener",
+				ResourceId: listenerArn,
+				Region:     client.AWSClient.Region,
+				Name:       listenerArn,
+				Tags:       tags,
+				FetchedAt:  time.Now(),
+				Link:       fmt.Sprintf("https://%s.console.aws.amazon.com/ec2/home?region=%s#ELBListenerV2:listenerArn=%s", client.AWSClient.Region, client.AWSClient.Region, listenerArn),
+			})
+		}
+
 	}
 
 	log.WithFields(log.Fields{

--- a/providers/aws/elb/loadbalancers.go
+++ b/providers/aws/elb/loadbalancers.go
@@ -68,17 +68,14 @@ func LoadBalancers(ctx context.Context, client ProviderClient) ([]Resource, erro
 		})
 
 		configListeners.LoadBalancerArn = &resourceArn
-		elblisClient := elasticloadbalancingv2.NewFromConfig(*client.AWSClient)
-
-		output, err := elblisClient.DescribeListeners(ctx, &configListeners)
+		output, err := elbClient.DescribeListeners(ctx, &configListeners)
 		if err != nil {
 			return resources, err
 		}
 
 		for _, listener := range output.Listeners {
 			listenerArn := *listener.ListenerArn
-
-			outputTags, err := elblisClient.DescribeTags(ctx, &elasticloadbalancingv2.DescribeTagsInput{
+			outputTags, err := elbClient.DescribeTags(ctx, &elasticloadbalancingv2.DescribeTagsInput{
 				ResourceArns: []string{listenerArn},
 			})
 			if err != nil {


### PR DESCRIPTION
## Problem

Solves #533 

## Solution

- Add functionality to get listeners 

## Changes Made

- Modified the existing `elb/loadbalancer.go` file with code to get listeners for each loadbalancer

## How to Test

- Make sure your AWS account has ELB Listeners
- Build and run this branch
- Choose `ELB Listener` as the service filter option

## Screenshots

![image](https://github.com/tailwarden/komiser/assets/25551553/04cd8895-6140-4324-b77c-48d417350663)



## Checklist

- [x] Code follows the <a href="https://github.com/tailwarden/komiser/blob/master/CONTRIBUTING.md">contributing</a> guidelines
- [x] Changes have been thoroughly tested
- [ ] <a href="https://github.com/tailwarden/docs.komiser.io">Documentation</a> has been updated, if necessary
- [x] Any dependencies have been added to the project, if necessary


