### PR TITLE
Added support for ELB and Listener types

### DIFF
--- a/providers/aws/elb/loadbalancers.go
+++ b/providers/aws/elb/loadbalancers.go
@@ -13,8 +13,20 @@ import (
 	"github.com/tailwarden/komiser/utils"
 )
 
+type ELBOptions struct {
+	elbType  string
+	elbPrice float64
+}
+
 func LoadBalancers(ctx context.Context, client ProviderClient) ([]Resource, error) {
 	resources := make([]Resource, 0)
+
+	elbValues := map[string]ELBOptions{
+		"application": {"Application", 0.0225},
+		"network":     {"Network", 0.0225},
+		"gateway":     {"Gateway", 0.0125},
+	}
+
 	var config elasticloadbalancingv2.DescribeLoadBalancersInput
 	elbClient := elasticloadbalancingv2.NewFromConfig(*client.AWSClient)
 
@@ -27,6 +39,8 @@ func LoadBalancers(ctx context.Context, client ProviderClient) ([]Resource, erro
 
 	for _, loadbalancer := range output.LoadBalancers {
 		resourceArn := *loadbalancer.LoadBalancerArn
+		resourceType := string(loadbalancer.Type)
+
 		outputTags, err := elbClient.DescribeTags(ctx, &elasticloadbalancingv2.DescribeTagsInput{
 			ResourceArns: []string{resourceArn},
 		})
@@ -51,12 +65,12 @@ func LoadBalancers(ctx context.Context, client ProviderClient) ([]Resource, erro
 		} else {
 			hourlyUsage = int(time.Since(*loadbalancer.CreatedTime).Hours())
 		}
-		monthlyCost := float64(hourlyUsage) * 0.0225
+		monthlyCost := float64(hourlyUsage) * elbValues[resourceType].elbPrice
 
 		resources = append(resources, Resource{
 			Provider:   "AWS",
 			Account:    client.Name,
-			Service:    "ELB",
+			Service:    "ELB" + " " + elbValues[resourceType].elbType,
 			ResourceId: resourceArn,
 			Region:     client.AWSClient.Region,
 			Name:       *loadbalancer.LoadBalancerName,
@@ -95,7 +109,7 @@ func LoadBalancers(ctx context.Context, client ProviderClient) ([]Resource, erro
 			resources = append(resources, Resource{
 				Provider:   "AWS",
 				Account:    client.Name,
-				Service:    "ELB Listener",
+				Service:    "ELB Listener" + " " + elbValues[resourceType].elbType,
 				ResourceId: listenerArn,
 				Region:     client.AWSClient.Region,
 				Name:       listenerArn,


### PR DESCRIPTION
## Problem

Fixes #539 #538 #537 #536

## Solution
- Updated code to show the different types of ELB and Listeners based on `loadbalancer.Type`

## Changes Made
- Added support to view different types of ELB's and Listeners


## How to Test
1. Make sure your AWS account has AWS Application/Network/Gateway ELB
2. Build and run this branch
3. Choose ELB Application/Network/Gateway as the service filter option
4. Follow step 3 but pick listeners.


## Screenshots

![image](https://github.com/tailwarden/komiser/assets/25551553/f7fdd964-1dcf-45ec-9294-46a7458f1afb)
## Notes

Need help testing Network and Gateway loadbalancer options

## Checklist

- [x] Code follows the <a href="https://github.com/tailwarden/komiser/blob/master/CONTRIBUTING.md">contributing</a> guidelines
- [ ] Changes have been thoroughly tested
- [ ] <a href="https://github.com/tailwarden/docs.komiser.io">Documentation</a> has been updated, if necessary
- [ ] Any dependencies have been added to the project, if necessary


