### PR TITLE
Disable Onboarding Wizard until Ready

### DIFF
--- a/dashboard/components/layout/Layout.tsx
+++ b/dashboard/components/layout/Layout.tsx
@@ -37,7 +37,7 @@ function Layout({ children }: LayoutProps) {
     }
   }, [telemetry]);
 
-  const betaFlagOnboardingWizard = true; // To test the onboarding wizard feature, set this beta-flag to true
+  const betaFlagOnboardingWizard = false; // To test the onboarding wizard feature, set this beta-flag to true
   const isOnboarding =
     betaFlagOnboardingWizard && router.pathname.startsWith('/onboarding');
 


### PR DESCRIPTION
## Problem
I just found that I was being redirected to the onboarding wizard everytime I was running the dashboard! This limits our current use because the wizard is not entirely functional!

## Solution
I have disabled it for now using the flag, and let's enable it after getting all the features for it made and thoroughly tested!

## Checklist
- [x] Code follows the <a href="https://github.com/tailwarden/komiser/blob/master/CONTRIBUTING.md">contributing</a> guidelines
- [x] Changes have been thoroughly tested
- [x] <a href="https://github.com/tailwarden/docs.komiser.io">Documentation</a> has been updated, if necessary
- [x] Any dependencies have been added to the project, if necessary

