### PR TITLE
remove api docs from sidebar

### DIFF
--- a/docs/mint.json
+++ b/docs/mint.json
@@ -76,19 +76,6 @@
     {
       "group": "Community & Support",
       "pages": ["community-support/contributing", "community-support/events", "community-support/telemetry", "community-support/faqs"]
-    },
-    {
-      "group": "API Documentation",
-      "pages": ["api-reference/authentication"]
-    },
-    {
-      "group": "Endpoint Examples",
-      "pages": [
-        "api-reference/endpoint/getting",
-        "api-reference/endpoint/create",
-        "api-reference/endpoint/update",
-        "api-reference/endpoint/delete"
-      ]
     }
   ],
   "footerSocials": {


### PR DESCRIPTION
Removed default api docs from the sidebar
![Screenshot 2023-09-14 at 10 45 06](https://github.com/tailwarden/komiser/assets/38757612/b30a453f-21dd-46aa-9d22-dd4056750bba)
