### PR TITLE
Expose config database endpoint

### DIFF
--- a/internal/api/v1/endpoints.go
+++ b/internal/api/v1/endpoints.go
@@ -63,6 +63,8 @@ func Endpoints(ctx context.Context, telemetry bool, analytics utils.Analytics, d
 	router.DELETE("/cloud_accounts/:id", api.DeleteCloudAccountHandler)
 	router.PUT("/cloud_accounts/:id", api.UpdateCloudAccountHandler)
 
+	router.POST("/databases", api.ConfigureDatabaseHandler)
+
 	router.NoRoute(gin.WrapH(http.FileServer(assetFS())))
 
 	return router

--- a/models/database.go
+++ b/models/database.go
@@ -1,0 +1,10 @@
+package models
+
+type DatabaseConfig struct {
+	Type     string `json:"type"`
+	Hostname string `json:"hostname"`
+	Database string `json:"database"`
+	Username string `json:"username"`
+	Password string `json:"password"`
+	File     string `json:"file"`
+}


### PR DESCRIPTION
## Problem

Through the new onboarding wizard, users would be able to connect Komiser to an external database (Postgres or SQLite), hence an API endpoint is needed to establish the connection.

## Solution

Exposed a new endpoint to allow users to connect an external database.

## How to Test

The following endpoint can be used to integrate a database:
`POST /databases`
It expects the following payload:
```json
{
    "type": "SQLITE",
    "file": "komiser.db"
}


{
    "type": "POSTGRES",
    "hostname": "localhost:5432",
    "username": "komiser",
    "password": "komiser",
    "database": "demo"
}
```
## Checklist

- [x] Code follows the <a href="https://github.com/tailwarden/komiser/blob/master/CONTRIBUTING.md">contributing</a> guidelines
- [x] Changes have been thoroughly tested
- [x] <a href="https://github.com/tailwarden/docs.komiser.io">Documentation</a> has been updated, if necessary
- [x] Any dependencies have been added to the project, if necessary

## Reviewers

@[username of the reviewer]

