### PR TITLE
Bigquery table cost calculation

### DIFF
--- a/providers/gcp/bigquery/tables.go
+++ b/providers/gcp/bigquery/tables.go
@@ -13,6 +13,27 @@ import (
 	"google.golang.org/api/option"
 )
 
+const (
+	ACTIVE_STORAGE   = "ACTIVE"
+	LONGTERM_STORAGE = "LONGTERM"
+)
+
+func getTableStorageClass(meta *bigquery.TableMetadata) string {
+	activeThreshold := time.Now().AddDate(0, 0, -90)
+	lastModified := meta.LastModifiedTime
+	if lastModified.After(activeThreshold) {
+		return ACTIVE_STORAGE
+	}
+	return LONGTERM_STORAGE
+}
+
+func getStoragePricingForBigQueryTable() map[string]float64 {
+	return map[string]float64{
+		ACTIVE_STORAGE:   0.02,
+		LONGTERM_STORAGE: 0.01,
+	}
+}
+
 func Tables(ctx context.Context, client providers.ProviderClient) ([]models.Resource, error) {
 	resources := make([]models.Resource, 0)
 
@@ -59,6 +80,9 @@ func Tables(ctx context.Context, client providers.ProviderClient) ([]models.Reso
 				})
 			}
 
+			storageClass := getTableStorageClass(tableMetadata)
+			monthlyCost := float64(tableMetadata.NumBytes) / (1024 * 1024 * 1024) * getStoragePricingForBigQueryTable()[storageClass]
+
 			resources = append(resources, models.Resource{
 				Provider:   "GCP",
 				Account:    client.Name,
@@ -68,6 +92,7 @@ func Tables(ctx context.Context, client providers.ProviderClient) ([]models.Reso
 				Name:       tableMetadata.Name,
 				FetchedAt:  time.Now(),
 				Tags:       tags,
+				Cost:       monthlyCost,
 				Link:       fmt.Sprintf("https://console.cloud.google.com/bigquery?project=%s&page=dataset&p=%s&d=%s", client.GCPClient.Credentials.ProjectID, client.GCPClient.Credentials.ProjectID, dataset.DatasetID),
 			})
 		}


### PR DESCRIPTION
## Problem

Issue #784 

## Solution

Cost for bigquery table is dependant on the storage class of the table and if table hasn't been modified in 90 days then it's in longterm storage else it's in active storage.

ref: [BigQuery Table pricing](https://cloud.google.com/bigquery/pricing#storage)

## Changes Made

- Added function for fetching storage class based pricing
- Added function to determine storage class


## Notes

- I didn't find any API by GCP for fetching latest prices, hence I've used hardcoded values.
- Assumed billing on logical bytes used, which is default. GCP has option for physical bytes too which has different rates.
- Fixes #784 

## Checklist

- [X] Code follows the <a href="https://github.com/tailwarden/komiser/blob/master/CONTRIBUTING.md">contributing</a> guidelines
- [ ] Changes have been thoroughly tested
- [ ] <a href="https://github.com/tailwarden/docs.komiser.io">Documentation</a> has been updated, if necessary
- [X] Any dependencies have been added to the project, if necessary

## Reviewers

@[username of the reviewer]

