### PR TITLE
Display onboarding wizard if no cloud account was connected

### DIFF
--- a/dashboard/components/cloud-account/hooks/useCloudAccounts/useCloudAccount.ts
+++ b/dashboard/components/cloud-account/hooks/useCloudAccounts/useCloudAccount.ts
@@ -27,26 +27,37 @@ function useCloudAccount() {
   const [cloudAccounts, setCloudAccounts] = useState<CloudAccount[]>([]);
   const [cloudAccountItem, setCloudAccountItem] = useState<CloudAccount>();
   const isNotCustomView = !router.query.view;
-  const [loading, setLoading] = useState(true);
-  const [error, setError] = useState(false);
+  const [isLoading, setIsLoading] = useState(true);
+  const [hasError, setHasError] = useState(false);
 
   useEffect(() => {
+    if (!isLoading) {
+      setIsLoading(true);
+    }
+
+    settingsService
+      .getOnboardingStatus()
+      .then(res => {
+        if (
+          res !== Error &&
+          res.onboarded === false &&
+          res.status === 'PENDING_DATABASE'
+        ) {
+          router.push('/onboarding/choose-database');
+        } else {
+          router.push('/onboarding/choose-cloud');
+        }
+      })
+      .finally(() => setIsLoading(false));
+
     settingsService.getCloudAccounts().then(res => {
-      if (!loading) {
-        setLoading(true);
-      }
-
-      if (error) {
-        setError(false);
-      }
-
       if (res === Error) {
-        setLoading(false);
-        setError(true);
+        setHasError(true);
       } else {
-        setLoading(false);
         setCloudAccounts(res);
       }
+
+      setIsLoading(false);
     });
   }, []);
 
@@ -67,11 +78,13 @@ function useCloudAccount() {
     setCloudAccountItem,
     goTo,
     toast,
+    hasError,
     setToast,
     dismissToast,
     cloudAccounts,
     setCloudAccounts,
-    isNotCustomView
+    isNotCustomView,
+    isLoading
   };
 }
 

--- a/dashboard/pages/cloud-accounts.tsx
+++ b/dashboard/pages/cloud-accounts.tsx
@@ -35,7 +35,8 @@ function CloudAccounts() {
     toast,
     setToast,
     dismissToast,
-    isNotCustomView
+    isNotCustomView,
+    isLoading
   } = useCloudAccount();
 
   useEffect(() => {
@@ -68,7 +69,7 @@ function CloudAccounts() {
     setIsDeleteModalOpen(false);
   };
 
-  if (!cloudAccounts) return null;
+  if (!cloudAccounts || isLoading) return null;
 
   return (
     <>

--- a/dashboard/services/settingsService.ts
+++ b/dashboard/services/settingsService.ts
@@ -421,6 +421,16 @@ const settingsService = {
     } catch (error) {
       return Error;
     }
+  },
+
+  async getOnboardingStatus() {
+    try {
+      const res = await fetch(`${BASE_URL}/is_onboarded`, settings('GET'));
+      const data = await res.json();
+      return data;
+    } catch (error) {
+      return Error;
+    }
   }
 };
 


### PR DESCRIPTION
## Problem

Today a user can access the Cloud accounts page even if he hasn't added any accounts.

## Solution

This PR check with the API if the onboarding has been completed (both cloud accounts and database has been setup) and if not it redirects them to the corresponding page.

## Changes Made

- [List the changes you made in this pull request, including any new features or bug fixes.]

## How to Test

[Provide instructions on how to test the changes you made, including any relevant details like configuration steps or data to be used for testing.]

## Screenshots

[Include screenshots, if relevant, to help reviewers understand the changes you made.]

## Notes

[Any additional notes or information that you would like to share with the reviewers.]

## Checklist

- [x] Code follows the <a href="https://github.com/tailwarden/komiser/blob/master/CONTRIBUTING.md">contributing</a> guidelines
- [x] Changes have been thoroughly tested
- [x] <a href="https://github.com/tailwarden/docs.komiser.io">Documentation</a> has been updated, if necessary
- [x] Any dependencies have been added to the project, if necessary

## Reviewers

@[username of the reviewer]

