### PR TITLE
support aws iam user

### DIFF
--- a/providers/aws/aws.go
+++ b/providers/aws/aws.go
@@ -48,6 +48,7 @@ func listOfSupportedServices() []providers.FetchDataFunction {
 		iam.SamlProviders,
 		iam.Groups,
 		iam.Policies,
+		iam.Users,
 		sqs.Queues,
 		s3.Buckets,
 		ec2.Instances,

--- a/providers/aws/iam/users.go
+++ b/providers/aws/iam/users.go
@@ -1,0 +1,69 @@
+package iam
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/iam"
+	log "github.com/sirupsen/logrus"
+	"github.com/tailwarden/komiser/models"
+	"github.com/tailwarden/komiser/providers"
+)
+
+const (
+	iamUserLinkTemplate = "https://%s.console.aws.amazon.com/iamv2/home?region=%s#/users/details/%s"
+	awsProvider         = "AWS"
+	iamUserService      = "IAM User"
+)
+
+func Users(ctx context.Context, client providers.ProviderClient) ([]models.Resource, error) {
+	var resources []models.Resource
+
+	iamClient := iam.NewFromConfig(*client.AWSClient)
+
+	paginator := iam.NewListUsersPaginator(iamClient, &iam.ListUsersInput{})
+
+	for paginator.HasMorePages() {
+		output, err := paginator.NextPage(ctx)
+		if err != nil {
+			log.WithError(err).Error("Failed to list IAM users")
+			return nil, fmt.Errorf("failed to list IAM users: %w", err)
+		}
+
+		for _, o := range output.Users {
+			var tags []models.Tag
+			for _, t := range o.Tags {
+				tags = append(tags, models.Tag{
+					Key:   aws.ToString(t.Key),
+					Value: aws.ToString(t.Value),
+				})
+			}
+
+			resources = append(resources, models.Resource{
+				Provider:   awsProvider,
+				Account:    client.Name,
+				Service:    iamUserService,
+				ResourceId: aws.ToString(o.Arn),
+				Region:     client.AWSClient.Region,
+				Name:       aws.ToString(o.UserName),
+				Cost:       0,
+				CreatedAt:  *o.CreateDate,
+				Tags:       tags,
+				FetchedAt:  time.Now(),
+				Link:       fmt.Sprintf(iamUserLinkTemplate, client.AWSClient.Region, client.AWSClient.Region, aws.ToString(o.UserName)),
+			})
+		}
+	}
+
+	log.WithFields(log.Fields{
+		"provider":  awsProvider,
+		"account":   client.Name,
+		"region":    client.AWSClient.Region,
+		"service":   iamUserService,
+		"resources": len(resources),
+	}).Info("Fetched resources")
+
+	return resources, nil
+}


### PR DESCRIPTION
## Problem

Ability to see AWS IAM Users did not exist

## Solution

This PR adds a new `user.go` file which queries the AWS v2 Go SDK and implements support for calculating AWS IAM Users.
An entry has also been made to `aws.go` to make sure `iam.Users` is included.

## Changes Made

fixes #547 

## How to Test

Open Dashboard and apply relevant filters to see iam users

## Screenshots

<img width="1918" alt="Screenshot 2023-09-23 at 10 48 31 PM" src="https://github.com/tailwarden/komiser/assets/64726664/74c3b85e-1339-4162-9dbb-ceaa2697e8c0">

## Checklist

- [x] Code follows the <a href="https://github.com/tailwarden/komiser/blob/master/CONTRIBUTING.md">contributing</a> guidelines
- [x] Changes have been thoroughly tested
- [x] <a href="https://github.com/tailwarden/docs.komiser.io">Documentation</a> has been updated, if necessary
- [x] Any dependencies have been added to the project, if necessary

## Reviewers

@mlabouardy @jakepage91

