### PR TITLE
Fix. Analytics provider to Civo instead of Azure

### DIFF
--- a/providers/civo/civo.go
+++ b/providers/civo/civo.go
@@ -56,7 +56,7 @@ func FetchResources(ctx context.Context, client providers.ProviderClient, db *bu
 				}
 				if telemetry {
 					analytics.TrackEvent("discovered_resources", map[string]interface{}{
-						"provider":  "Azure",
+						"provider":  "Civo",
 						"resources": len(resources),
 					})
 				}


### PR DESCRIPTION
## Description

Fixes #1001 
Change provider label to Civo instead of Azure

@mlabouardy 

Would be great if you can include `hacktoberfest-accepted` label to this PR.

