### PR TITLE
Cost explorer

### DIFF
--- a/dashboard/components/dashboard/components/cost-explorer/hooks/useCostExplorer.tsx
+++ b/dashboard/components/dashboard/components/cost-explorer/hooks/useCostExplorer.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useRef, useState } from 'react';
 import settingsService from '../../../../../services/settingsService';
 import dateHelper, {
+  thisMonth,
   lastMonth,
   lastSixMonths,
   lastThreeMonths,
@@ -23,6 +24,7 @@ export type CostExplorerQueryGroupProps =
   | 'view';
 export type CostExplorerQueryGranularityProps = 'monthly' | 'daily';
 export type CostExplorerQueryDateProps =
+  | 'thisMonth'
   | 'lastMonth'
   | 'lastThreeMonths'
   | 'lastSixMonths'
@@ -58,6 +60,9 @@ function useCostExplorer() {
     let startDate = '';
     let endDate = '';
 
+    if (queryDate === 'thisMonth') {
+      [startDate, endDate] = thisMonth;
+    }
     if (queryDate === 'lastMonth') {
       [startDate, endDate] = lastMonth;
     }

--- a/dashboard/components/dashboard/components/cost-explorer/hooks/useCostExplorerChart.tsx
+++ b/dashboard/components/dashboard/components/cost-explorer/hooks/useCostExplorerChart.tsx
@@ -100,12 +100,14 @@ function useCostExplorerChart({
 
   const dateSelect = {
     values: [
+      'thisMonth',
       'lastMonth',
       'lastThreeMonths',
       'lastSixMonths',
       'lastTwelveMonths'
     ],
     displayValues: [
+      'This month',
       'Last month',
       'Last 3 months',
       'Last 6 months',

--- a/dashboard/components/dashboard/components/cost-explorer/utils/dateHelper.ts
+++ b/dashboard/components/dashboard/components/cost-explorer/utils/dateHelper.ts
@@ -4,6 +4,12 @@ const dateHelper = {
     return date.toJSON().slice(0, 10);
   },
 
+  getFirstDayOfThisMonth() {
+    const date = new Date();
+    date.setDate(1);
+    return date.toJSON().slice(0, 10);
+  },
+
   getLastMonth() {
     const date = new Date();
     date.setDate(1);
@@ -71,7 +77,10 @@ export function dateFormatter(dateParam: string, granularity: string) {
   }
   return formattedDate;
 }
-
+export const thisMonth = [
+  dateHelper.getFirstDayOfThisMonth(),
+  dateHelper.getToday()
+];
 export const lastMonth = [
   dateHelper.getLastMonth(),
   dateHelper.getLastDayOfLastMonth()

--- a/dashboard/components/dashboard/components/cost-explorer/utils/dateHelper.ts
+++ b/dashboard/components/dashboard/components/cost-explorer/utils/dateHelper.ts
@@ -91,7 +91,7 @@ export const lastThreeMonths = [
 ];
 export const lastSixMonths = [
   dateHelper.getLastSixMonths(),
-  dateHelper.getToday()
+  dateHelper.getLastDayOfLastMonth()
 ];
 export const lastTwelveMonths = [
   dateHelper.getLastTwelveMonths(),


### PR DESCRIPTION
## Problem

#811  

## Solution

Fixed the  period  filter for "Last 6 months" to exclude this month and added a new period  filter for "This month" in cost explorer.

## Changes Made

- Added a date helper function for getting first day of this month.
- Added the UI option for selecting "This month" period & subsequent changes to support that option.

## How to Test

- Try cost explorer with "This month" period, it'll show data for only this month.
- Try cost explorer with "Last 6 months" period, it won't include this month's data anymore.

## Screenshots

![image](https://github.com/tailwarden/komiser/assets/42029519/f3a584d6-a30c-42b9-93d6-7f005bedfd55)
![image](https://github.com/tailwarden/komiser/assets/42029519/78d4ec8f-29ec-4751-b4c9-62bfffab0316)

## Notes

- Fixes #811 
- I considered adding date pickers or date range widget but skipped it now for the lack of a design.

## Checklist

- [X] Code follows the <a href="https://github.com/tailwarden/komiser/blob/master/CONTRIBUTING.md">contributing</a> guidelines
- [X] Changes have been thoroughly tested
- [ ] <a href="https://github.com/tailwarden/docs.komiser.io">Documentation</a> has been updated, if necessary
- [X] Any dependencies have been added to the project, if necessary

## Reviewers

@mlabouardy 
@naisayer
