### PR TITLE
opencost struct types update

### DIFF
--- a/providers/k8s/opencost/opencost.go
+++ b/providers/k8s/opencost/opencost.go
@@ -16,12 +16,18 @@ type OpenCostResponse struct {
 
 type costData struct {
 	Properties struct {
-		Cluster string `json:"cluster"`
-		Node    string `json:"node"`
+		Cluster        string `json:"cluster"`
+		Node           string `json:"node"`
+		Controller     string `json:"controller"`
+		Pod            string `json:"pod"`
+		ProviderID     string `json:"providerID"`
+		Namespace      string `json:"namespace"`
+		ControllerKind string `json:"controllerKind"`
 	} `json:"properties"`
+	Window             Window            `json:"window"`
 	Start              time.Time         `json:"start"`
 	End                time.Time         `json:"end"`
-	Minutes            int               `json:"minutes"`
+	Minutes            float64           `json:"minutes"`
 	CPUCores           float64           `json:"cpuCores"`
 	CPUCoreRequestAvg  float64           `json:"cpuCoreRequestAverage"`
 	CPUCoreUsageAvg    float64           `json:"cpuCoreUsageAverage"`
@@ -29,12 +35,12 @@ type costData struct {
 	CPUCost            float64           `json:"cpuCost"`
 	CPUCostAdjustment  float64           `json:"cpuCostAdjustment"`
 	CPUEfficiency      float64           `json:"cpuEfficiency"`
-	GPUCount           int               `json:"gpuCount"`
-	GPUHours           int               `json:"gpuHours"`
+	GPUCount           float64           `json:"gpuCount"`
+	GPUHours           float64           `json:"gpuHours"`
 	GPUCost            float64           `json:"gpuCost"`
 	GPUCostAdjustment  float64           `json:"gpuCostAdjustment"`
-	NetworkTransfer    int64             `json:"networkTransferBytes"`
-	NetworkReceive     int64             `json:"networkReceiveBytes"`
+	NetworkTransfer    float64           `json:"networkTransferBytes"`
+	NetworkReceive     float64           `json:"networkReceiveBytes"`
 	NetworkCost        float64           `json:"networkCost"`
 	NetworkCrossZone   float64           `json:"networkCrossZoneCost"`
 	NetworkCrossRegion float64           `json:"networkCrossRegionCost"`
@@ -42,14 +48,14 @@ type costData struct {
 	NetworkAdjustment  float64           `json:"networkCostAdjustment"`
 	LoadBalancerCost   float64           `json:"loadBalancerCost"`
 	LBCostAdjustment   float64           `json:"loadBalancerCostAdjustment"`
-	PVBytes            int64             `json:"pvBytes"`
+	PVBytes            float64           `json:"pvBytes"`
 	PVByteHours        float64           `json:"pvByteHours"`
 	PVCost             float64           `json:"pvCost"`
 	PVs                map[string]pvInfo `json:"pvs"`
 	PVCostAdjustment   float64           `json:"pvCostAdjustment"`
-	RAMBytes           int64             `json:"ramBytes"`
-	RAMByteRequestAvg  int64             `json:"ramByteRequestAverage"`
-	RAMByteUsageAvg    int64             `json:"ramByteUsageAverage"`
+	RAMBytes           float64           `json:"ramBytes"`
+	RAMByteRequestAvg  float64           `json:"ramByteRequestAverage"`
+	RAMByteUsageAvg    float64           `json:"ramByteUsageAverage"`
 	RAMByteHours       float64           `json:"ramByteHours"`
 	RAMCost            float64           `json:"ramCost"`
 	RAMCostAdjustment  float64           `json:"ramCostAdjustment"`
@@ -58,6 +64,11 @@ type costData struct {
 	SharedCost         float64           `json:"sharedCost"`
 	TotalCost          float64           `json:"totalCost"`
 	TotalEfficiency    float64           `json:"totalEfficiency"`
+}
+
+type Window struct {
+	Start string `json:"start"`
+	End   string `json:"end"`
 }
 
 type pvInfo struct {

--- a/providers/k8s/opencost/opencost.go
+++ b/providers/k8s/opencost/opencost.go
@@ -8,6 +8,12 @@ import (
 	"time"
 )
 
+// Opencost reference for the structs defined here
+//
+// Swagger: https://github.com/opencost/opencost/blob/develop/docs/swagger.json
+// Go struct: https://github.com/opencost/opencost/blob/6a7d9ada3cd0422701c90b5df214b8bf322b0e62/pkg/kubecost/allocation_json.go#L13
+//
+
 type OpenCostResponse struct {
 	Code   int                   `json:"code"`
 	Status string                `json:"status"`


### PR DESCRIPTION
## Problem

All Opencost fields are` float64` in their structs and `number` in swagger. Using `int` on our end may cause issues.

ref:-
- https://github.com/opencost/opencost/blob/develop/docs/swagger.json
- https://github.com/opencost/opencost/blob/6a7d9ada3cd0422701c90b5df214b8bf322b0e62/pkg/kubecost/allocation_json.go#L13

## Solution

Converted all `int` fields to `float64` in opencost costdata struct.

## Changes Made

- Added the references as code comments
- Converted all `int` fields to `float64` in the relevant struct.
- Added more fields which might be useful in the future

## Checklist

- [X] Code follows the <a href="https://github.com/tailwarden/komiser/blob/master/CONTRIBUTING.md">contributing</a> guidelines
- [X] Changes have been thoroughly tested
- [ ] <a href="https://github.com/tailwarden/docs.komiser.io">Documentation</a> has been updated, if necessary
- [X] Any dependencies have been added to the project, if necessary

## Reviewers

@mlabouardy 
@AvineshTripathi 

