### PR TITLE
Aws Lambda cost calculation improvements

### DIFF
--- a/providers/aws/lambda/functions.go
+++ b/providers/aws/lambda/functions.go
@@ -12,18 +12,48 @@ import (
 	cloudwatchTypes "github.com/aws/aws-sdk-go-v2/service/cloudwatch/types"
 	"github.com/aws/aws-sdk-go-v2/service/iam"
 	"github.com/aws/aws-sdk-go-v2/service/lambda"
-	"github.com/aws/aws-sdk-go-v2/service/lambda/types"
+	lambdaTypes "github.com/aws/aws-sdk-go-v2/service/lambda/types"
+	"github.com/aws/aws-sdk-go-v2/service/pricing"
+	"github.com/aws/aws-sdk-go-v2/service/pricing/types"
 	"github.com/tailwarden/komiser/models"
-	. "github.com/tailwarden/komiser/models"
-	. "github.com/tailwarden/komiser/providers"
+	"github.com/tailwarden/komiser/providers"
+	awsUtils "github.com/tailwarden/komiser/providers/aws/utils"
 	"github.com/tailwarden/komiser/utils"
 )
 
-func Functions(ctx context.Context, client ProviderClient) ([]Resource, error) {
+const (
+	freeTierInvocations = 1000000
+	freeTierDuration    = 400000
+)
+
+func Functions(ctx context.Context, client providers.ProviderClient) ([]models.Resource, error) {
 	var config lambda.ListFunctionsInput
-	resources := make([]Resource, 0)
+	resources := make([]models.Resource, 0)
 	cloudwatchClient := cloudwatch.NewFromConfig(*client.AWSClient)
 	lambdaClient := lambda.NewFromConfig(*client.AWSClient)
+	pricingClient := pricing.NewFromConfig(*client.AWSClient)
+
+	pricingOutput, err := pricingClient.GetProducts(ctx, &pricing.GetProductsInput{
+		ServiceCode: aws.String("AWSLambda"),
+		Filters: []types.Filter{
+			{
+				Field: aws.String("regionCode"),
+				Value: aws.String(client.AWSClient.Region),
+				Type:  types.FilterTypeTermMatch,
+			},
+		},
+	})
+	if err != nil {
+		log.Errorf("ERROR: Couldn't fetch pricing info for AWS Lambda: %v", err)
+		return resources, err
+	}
+
+	priceMap, err := awsUtils.GetPriceMap(pricingOutput)
+	if err != nil {
+		log.Errorf("ERROR: Failed to calculate cost per month: %v", err)
+		return resources, err
+	}
+
 	for {
 		output, err := lambdaClient.ListFunctions(context.Background(), &config)
 		if err != nil {
@@ -31,6 +61,11 @@ func Functions(ctx context.Context, client ProviderClient) ([]Resource, error) {
 		}
 
 		for _, o := range output.Functions {
+			archSuffix := ""
+			if o.Architectures[0] == lambdaTypes.ArchitectureArm64 {
+				archSuffix = "-ARM"
+			}
+
 			metricsInvocationsOutput, err := cloudwatchClient.GetMetricStatistics(ctx, &cloudwatch.GetMetricStatisticsInput{
 				StartTime:  aws.Time(utils.BeginningOfMonth(time.Now())),
 				EndTime:    aws.Time(time.Now()),
@@ -49,12 +84,15 @@ func Functions(ctx context.Context, client ProviderClient) ([]Resource, error) {
 			})
 
 			if err != nil {
-				log.Warnf("Couldn't fetch invocations metric for %s", *o.FunctionName)
+				log.Warnf("Couldn't fetch invocations metric for %s: %v", *o.FunctionName, err)
 			}
 
 			invocations := 0.0
 			if metricsInvocationsOutput != nil && len(metricsInvocationsOutput.Datapoints) > 0 {
 				invocations = *metricsInvocationsOutput.Datapoints[0].Sum
+			}
+			if invocations > freeTierInvocations {
+				invocations -= freeTierInvocations
 			}
 
 			metricsDurationOutput, err := cloudwatchClient.GetMetricStatistics(ctx, &cloudwatch.GetMetricStatisticsInput{
@@ -74,26 +112,30 @@ func Functions(ctx context.Context, client ProviderClient) ([]Resource, error) {
 				},
 			})
 			if err != nil {
-				log.Warnf("Couldn't fetch duration metric for %s", *o.FunctionName)
+				log.Warnf("Couldn't fetch duration metric for %s: %v", *o.FunctionName, err)
 			}
 
 			duration := 0.0
 			if metricsDurationOutput != nil && len(metricsDurationOutput.Datapoints) > 0 {
 				duration = *metricsDurationOutput.Datapoints[0].Average
 			}
+			totalDuration := ((invocations * duration) * (float64(*o.MemorySize))) / (1024 * 1024)
+			if totalDuration < freeTierDuration {
+				totalDuration -= freeTierDuration
+			}
 
-			computeCharges := (((invocations * duration) * (float64(*o.MemorySize))) / 1024) * 0.0000000083
-			requestCharges := invocations * 0.2
+			computeCharges := awsUtils.GetCost(priceMap["AWS-Lambda-Duration"+archSuffix], totalDuration)
+			requestCharges := awsUtils.GetCost(priceMap["AWS-Lambda-Requests"+archSuffix], invocations)
 			monthlyCost := computeCharges + requestCharges
 
-			tags := make([]Tag, 0)
+			tags := make([]models.Tag, 0)
 			tagsResp, err := lambdaClient.ListTags(context.Background(), &lambda.ListTagsInput{
 				Resource: o.FunctionArn,
 			})
 
 			if err == nil {
 				for key, value := range tagsResp.Tags {
-					tags = append(tags, Tag{
+					tags = append(tags, models.Tag{
 						Key:   key,
 						Value: value,
 					})
@@ -102,7 +144,7 @@ func Functions(ctx context.Context, client ProviderClient) ([]Resource, error) {
 
 			relations := getLambdaRelations(*client.AWSClient, o)
 
-			resources = append(resources, Resource{
+			resources = append(resources, models.Resource{
 				Provider:   "AWS",
 				Account:    client.Name,
 				Service:    "Lambda",
@@ -136,7 +178,7 @@ func Functions(ctx context.Context, client ProviderClient) ([]Resource, error) {
 	return resources, nil
 }
 
-func getLambdaRelations(config aws.Config, lambda types.FunctionConfiguration) (rel []models.Link) {
+func getLambdaRelations(config aws.Config, lambda lambdaTypes.FunctionConfiguration) (rel []models.Link) {
 	// Get associated IAM roles
 	if lambda.Role != nil {
 		iamClient := iam.NewFromConfig(config)

--- a/providers/aws/utils/utils.go
+++ b/providers/aws/utils/utils.go
@@ -1,0 +1,74 @@
+package utils
+
+import (
+	"encoding/json"
+	"fmt"
+	"strconv"
+
+	"github.com/aws/aws-sdk-go-v2/service/pricing"
+)
+
+type ProductEntry struct {
+	Product struct {
+		Attributes struct {
+			Group     string `json:"group"`
+			Operation string `json:"operation"`
+		} `json:"attributes"`
+	} `json:"product"`
+	Terms struct {
+		OnDemand map[string]struct {
+			PriceDimensions map[string]PriceDimensions `json:"priceDimensions"`
+		} `json:"OnDemand"`
+	} `json:"terms"`
+}
+
+type PriceDimensions struct {
+	EndRange     string  `json:"endRange"`
+	BeginRange   float64 `json:"beginRange,string"`
+	PricePerUnit struct {
+		USD float64 `json:"USD,string"`
+	} `json:"pricePerUnit"`
+}
+
+func GetCost(pds []PriceDimensions, v float64) float64 {
+	total := 0.0
+	for _, pd := range pds {
+		applicableRange := v
+		if pd.BeginRange < v {
+			if pd.EndRange != "Inf" {
+				endRange, _ := strconv.ParseFloat(pd.EndRange, 64)
+				if v < endRange {
+					applicableRange = v
+				}
+			}
+			total += (applicableRange - pd.BeginRange) * pd.PricePerUnit.USD
+		}
+	}
+	return total
+}
+
+func GetPriceMap(pricingOutput *pricing.GetProductsOutput) (map[string][]PriceDimensions, error) {
+	priceMap := make(map[string][]PriceDimensions)
+
+	if pricingOutput != nil && len(pricingOutput.PriceList) > 0 {
+		for _, item := range pricingOutput.PriceList {
+			price := ProductEntry{}
+			err := json.Unmarshal([]byte(item), &price)
+			if err != nil {
+				return nil, fmt.Errorf("failed to unmarshal JSON: %w", err)
+			}
+
+			group := price.Product.Attributes.Group
+			unitPrices := []PriceDimensions{}
+			for _, pd := range price.Terms.OnDemand {
+				for _, p := range pd.PriceDimensions {
+					unitPrices = append(unitPrices, p)
+				}
+			}
+
+			priceMap[group] = unitPrices
+		}
+	}
+
+	return priceMap, nil
+}

--- a/providers/aws/utils/utils.go
+++ b/providers/aws/utils/utils.go
@@ -37,8 +37,8 @@ func GetCost(pds []PriceDimensions, v float64) float64 {
 		if pd.BeginRange < v {
 			if pd.EndRange != "Inf" {
 				endRange, _ := strconv.ParseFloat(pd.EndRange, 64)
-				if v < endRange {
-					applicableRange = v
+				if v > endRange {
+					applicableRange = endRange
 				}
 			}
 			total += (applicableRange - pd.BeginRange) * pd.PricePerUnit.USD

--- a/providers/aws/utils/utils_test.go
+++ b/providers/aws/utils/utils_test.go
@@ -1,0 +1,204 @@
+package utils
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/aws/aws-sdk-go-v2/service/pricing"
+)
+
+func TestGetCost(t *testing.T) {
+	// Single price dimension
+	pd := PriceDimensions{
+		BeginRange: 0,
+		EndRange:   "Inf",
+		PricePerUnit: struct {
+			USD float64 `json:"USD,string"`
+		}{USD: 0.1},
+	}
+	pds := []PriceDimensions{pd}
+	cost := GetCost(pds, 10.0)
+	expected := 1.0
+	if cost != expected {
+		t.Errorf("Expected cost: %f, but got: %f", expected, cost)
+	}
+
+	// Multiple price dimensions
+	pd1 := PriceDimensions{
+		BeginRange: 0,
+		EndRange:   "10",
+		PricePerUnit: struct {
+			USD float64 `json:"USD,string"`
+		}{USD: 0.2},
+	}
+	pd2 := PriceDimensions{
+		BeginRange: 10,
+		EndRange:   "Inf",
+		PricePerUnit: struct {
+			USD float64 `json:"USD,string"`
+		}{USD: 0.1},
+	}
+	pds = []PriceDimensions{pd1, pd2}
+	cost = GetCost(pds, 20)
+	expected = 3.0
+	if cost != expected {
+		t.Errorf("Expected cost: %f, but got: %f", expected, cost)
+	}
+}
+
+func TestGetPriceMap(t *testing.T) {
+	testCases := []struct {
+		inputPriceList       []string
+		expectedNumProducts  int
+		expectedNumPriceDims map[string]int
+	}{
+		// Minimal valid JSON input with a single product and price dimension
+		{
+			inputPriceList: []string{`
+				{
+					"product": {
+						"attributes": {
+							"group": "TestGroup"
+						}
+					},
+					"terms": {
+						"OnDemand": {
+							"test_term": {
+								"priceDimensions": {
+									"test_price_dimension": {
+										"beginRange": "0",
+										"endRange": "Inf",
+										"pricePerUnit": {
+											"USD": "0.1"
+										}
+									}
+								}
+							}
+						}
+					}
+				}`},
+			expectedNumProducts:  1,
+			expectedNumPriceDims: map[string]int{"TestGroup": 1},
+		},
+		// Multiple products with different price dimensions
+		{
+			inputPriceList: []string{
+				// Product 1 with 2 price dimensions
+				`
+				{
+					"product": {
+						"attributes": {
+							"group": "TestGroup1"
+						}
+					},
+					"terms": {
+						"OnDemand": {
+							"test_term": {
+								"priceDimensions": {
+									"test_price_dimension1": {
+										"beginRange": "0",
+										"endRange": "100",
+										"pricePerUnit": {
+											"USD": "0.2"
+										}
+									},
+									"test_price_dimension2": {
+										"beginRange": "100",
+										"endRange": "Inf",
+										"pricePerUnit": {
+											"USD": "0.3"
+										}
+									}
+								}
+							}
+						}
+					}
+				}`,
+				// Product 2 with 3 price dimensions
+				`
+				{
+					"product": {
+						"attributes": {
+							"group": "TestGroup2"
+						}
+					},
+					"terms": {
+						"OnDemand": {
+							"test_term": {
+								"priceDimensions": {
+									"test_price_dimension1": {
+										"beginRange": "0",
+										"endRange": "50",
+										"pricePerUnit": {
+											"USD": "0.1"
+										}
+									},
+									"test_price_dimension2": {
+										"beginRange": "50",
+										"endRange": "100",
+										"pricePerUnit": {
+											"USD": "0.15"
+										}
+									},
+									"test_price_dimension3": {
+										"beginRange": "100",
+										"endRange": "Inf",
+										"pricePerUnit": {
+											"USD": "0.2"
+										}
+									}
+								}
+							}
+						}
+					}
+				}`,
+			},
+			expectedNumProducts:  2,
+			expectedNumPriceDims: map[string]int{"TestGroup1": 2, "TestGroup2": 3},
+		},
+	}
+	for i, testCase := range testCases {
+		t.Run(fmt.Sprintf("Test case %d", i+1), func(t *testing.T) {
+			output := pricing.GetProductsOutput{
+				PriceList: testCase.inputPriceList,
+			}
+			priceMap, err := GetPriceMap(&output)
+			if err != nil {
+				t.Errorf("Expected no error, but got: %v", err)
+			}
+
+			if len(priceMap) != testCase.expectedNumProducts {
+				t.Errorf("Expected %d products in priceMap, but got %d", testCase.expectedNumProducts, len(priceMap))
+			}
+
+			for group, priceDims := range priceMap {
+				if len(priceDims) != testCase.expectedNumPriceDims[group] {
+					t.Errorf("Expected %d price dimensions for group %s, but got %d", testCase.expectedNumPriceDims[group], group, len(priceDims))
+				}
+			}
+		})
+	}
+}
+
+func TestGetPriceMap_InvalidJSON(t *testing.T) {
+	// Invalid JSON input
+	invalidJSON := "invalid JSON"
+	output := pricing.GetProductsOutput{
+		PriceList: []string{invalidJSON},
+	}
+	_, err := GetPriceMap(&output)
+	if err == nil {
+		t.Error("Expected an error, but got nil")
+	}
+}
+
+func TestGetPriceMap_NoPricingOutput(t *testing.T) {
+	// PricingOutput is nil
+	priceMap, err := GetPriceMap(nil)
+	if err != nil {
+		t.Errorf("Expected no error, but got: %v", err)
+	}
+	if len(priceMap) != 0 {
+		t.Errorf("Expected an empty priceMap, but got %v", priceMap)
+	}
+}


### PR DESCRIPTION
## Problem

AWS Lambda costs were off by ~1000x magnitude.

## Solution

The calculation for duration was off, it needed to bed divided by 1024 to get correct units.

## Changes Made

- Added common utils for AWS cost calculations
- Fixed AWS Lambda cost calculation
- Took free tier into account

## Notes

- Pay more attention towards the common utils as, if correctly implemented, these can be used throughout aws provider.

## Checklist

- [X] Code follows the <a href="https://github.com/tailwarden/komiser/blob/master/CONTRIBUTING.md">contributing</a> guidelines
- [X] Changes have been thoroughly tested
- [ ] <a href="https://github.com/tailwarden/docs.komiser.io">Documentation</a> has been updated, if necessary
- [X] Any dependencies have been added to the project, if necessary
