### PR TITLE
fix: fix tooltip component positioning and add it to storybook

### DIFF
--- a/dashboard/components/explorer/DependencyGraph.tsx
+++ b/dashboard/components/explorer/DependencyGraph.tsx
@@ -151,7 +151,7 @@ const DependencyGraph = ({ data }: DependencyGraphProps) => {
         {data?.nodes?.length} Resources
         <div className="relative">
           <WarningIcon className="peer" height="16" width="16" />
-          <Tooltip top="sm" align="right" width="lg">
+          <Tooltip bottom="xs" align="left" width="lg">
             Only AWS resources are currently supported on the explorer.
           </Tooltip>
         </div>

--- a/dashboard/components/tooltip/Tooltip.stories.tsx
+++ b/dashboard/components/tooltip/Tooltip.stories.tsx
@@ -1,0 +1,67 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import WarningIcon from '@components/icons/WarningIcon';
+import Tooltip from './Tooltip';
+
+// More on how to set up stories at: https://storybook.js.org/docs/7.0/react/writing-stories/introduction
+const meta: Meta<typeof Tooltip> = {
+  title: 'Komiser/Tooltip',
+  component: Tooltip,
+  parameters: {
+    docs: {
+      description: {
+        component:
+          // eslint-disable-next-line no-multi-str
+          'The tooltip component required to be wrapped inside an relative positioned container. There also need to be a trigger element which is required to have `className="peer"`!\
+          In this example the strigger element is the Info icon.\
+          The Storybook preview gives you an idea about possible parameters but might not work 100% because you should either define top **or** bottom, **not** both.\
+          To allow to show all possible options, we define both top, bottom and left, right in this example. Please keep this in mind!'
+      }
+    }
+  },
+  tags: ['autodocs'],
+  decorators: [
+    Story => (
+      <div className="flex h-96 items-center justify-center">
+        <div className="relative h-[16px] w-[16px]">
+          <WarningIcon className="peer" height="16" width="16" />
+          <Story />
+        </div>
+      </div>
+    )
+  ],
+  argTypes: {
+    top: {
+      control: {
+        type: 'inline-radio'
+      }
+    },
+    bottom: {
+      control: {
+        type: 'inline-radio'
+      }
+    },
+    align: {
+      control: {
+        type: 'inline-radio'
+      }
+    },
+    width: {
+      control: {
+        type: 'inline-radio'
+      }
+    }
+  }
+};
+
+export default meta;
+type Story = StoryObj<typeof Tooltip>;
+
+// More on writing stories with args: https://storybook.js.org/docs/7.0/react/writing-stories/args
+export const TopTiny: Story = {
+  args: {
+    top: 'xs',
+    align: 'left',
+    width: 'lg',
+    children: "That's a tooltip"
+  }
+};

--- a/dashboard/components/tooltip/Tooltip.tsx
+++ b/dashboard/components/tooltip/Tooltip.tsx
@@ -3,7 +3,8 @@ import { ReactNode } from 'react';
 
 type TooltipProps = {
   children: ReactNode;
-  top?: 'sm' | 'md' | 'lg';
+  top?: 'xs' | 'sm' | 'md' | 'lg';
+  bottom?: 'xs' | 'sm' | 'md' | 'lg';
   align?: 'left' | 'center' | 'right';
   width?: 'sm' | 'md' | 'lg';
 };
@@ -12,15 +13,24 @@ function Tooltip({
   children,
   top = 'md',
   align = 'left',
-  width = 'md'
+  width = 'md',
+  bottom
 }: TooltipProps) {
   return (
     <div
       role="tooltip"
       className={classNames(
-        'absolute left-6 top-24 z-[1000] hidden animate-fade-in-up items-center rounded-lg bg-black-900 px-4 py-2 text-xs font-medium text-black-200 opacity-0 peer-hover:flex',
-        { 'top-[3rem]': top === 'sm' },
-        { 'left-auto right-0': align === 'right' },
+        'absolute z-[1000] hidden animate-fade-in-up items-center rounded-lg bg-black-900 px-4 py-2 text-xs font-medium text-black-200 opacity-0 peer-hover:flex',
+        { 'top-0': top === 'xs' && !bottom },
+        { 'top-[3rem]': top === 'sm' && !bottom },
+        { 'top-24': top === 'md' && !bottom },
+        { 'top-36': top === 'lg' && !bottom },
+        { 'bottom-0': bottom === 'xs' },
+        { 'bottom-[3rem]': bottom === 'sm' },
+        { 'bottom-24': bottom === 'md' },
+        { 'bottom-36': bottom === 'lg' },
+        { 'left-6': align === 'left' },
+        { 'right-6': align === 'right' },
         { 'w-72': width === 'lg' }
       )}
     >


### PR DESCRIPTION
## Problem

The tooltip is broken in a way that for unknown reasons `classNames` is not overriding classes properly. Taking the following component:

```typescript
function Tooltip({
  children,
  top = 'md',
  align = 'left',
  width = 'md'
}: TooltipProps) {
  console.log(top, 'top');
  return (
    <div
      role="tooltip"
      className={classNames(
        'absolute left-6 top-24 z-[1000] hidden animate-fade-in-up items-center rounded-lg bg-black-900 px-4 py-2 text-xs font-medium text-black-200 opacity-0 peer-hover:flex',
        { 'top-0': top === 'xs' },
        { 'top-[3rem]': top === 'sm' },
        { 'left-auto right-0': align === 'right' },
        { 'w-72': width === 'lg' }
      )}
    >
      {children}
    </div>
  );
}
```

and using it as follows

```typescript
<div className="relative">
  <WarningIcon className="peer" height="16" width="16" />
  <Tooltip top="xs" align="left" width="lg">
    Only AWS resources are currently supported on the explorer.
  </Tooltip>
</div>
```

renders the following HTML

![Screenshot 2023-10-04 at 12 22 29](https://github.com/tailwarden/komiser/assets/320272/3ae69142-52d8-471c-9e7b-512ea76e784a)

and as you can see there is still the` top-24` being applied and the `top-0` is doing nothing.
Logging the `top` property shows that it is indeed passed in correctly:

![Screenshot 2023-10-04 at 12 22 37](https://github.com/tailwarden/komiser/assets/320272/36683ac6-81a9-4b19-85d5-0dc2a2cc7d8e)

However the rendering is completely off and not working as expected

![Screenshot 2023-10-04 at 13 23 27](https://github.com/tailwarden/komiser/assets/320272/509d0965-0470-40ef-a561-224d009f2a24)

## Solution

I fixed the class composition and added some more properties to also allow it to be positioned from the bottom. I kept the current positioning syntax to not break existing tooltips throughout Komiser.

I also added a Storybook component since it was not super clear from the beginning on how to actually use the component. I hope that the Story makes this a bit more clear that you need to wrap the Tooltip inside a relative positioned container and that you need to have an `peer` element which works as a trigger for the tooltip to show!

## Changes Made

- Fix the Tooltip component
- Add more options like `bottom` to allow all varieties of positioning
- Add Story for documentation purposes
- Use the new options in the dependency graph to have a properly positioned Tooltip

## How to Test

Either check out the branch or check Storybook

## Screenshots

![Screenshot 2023-10-04 at 13 11 11](https://github.com/tailwarden/komiser/assets/320272/8efaf852-ceca-4d1d-ae65-3bc80ea164a0)
![Screenshot 2023-10-04 at 13 12 24](https://github.com/tailwarden/komiser/assets/320272/e73e2d64-63fb-479c-bc03-04c7c3182e08)


## Notes

None

## Checklist

- [x] Code follows the <a href="https://github.com/tailwarden/komiser/blob/master/CONTRIBUTING.md">contributing</a> guidelines
- [x] Changes have been thoroughly tested
- [x] <a href="https://github.com/tailwarden/docs.komiser.io">Documentation</a> has been updated, if necessary
- [x] Any dependencies have been added to the project, if necessary

## Reviewers

To be reviewed by code owners

