### PR TITLE
fix: prevent redirecting when not visiting the onboarding wizard

### DIFF
--- a/dashboard/components/layout/Layout.tsx
+++ b/dashboard/components/layout/Layout.tsx
@@ -28,7 +28,11 @@ function Layout({ children }: LayoutProps) {
 
   useEffect(() => {
     settingsService.getOnboardingStatus().then(res => {
-      if (res.onboarded === true && res.status === 'COMPLETE') {
+      if (
+        res.onboarded === true &&
+        res.status === 'COMPLETE' &&
+        router.asPath.includes('/onboarding/')
+      ) {
         router.replace('/dashboard/');
       } else if (res.onboarded === false && res.status === 'PENDING_DATABASE') {
         router.replace('/onboarding/choose-database');


### PR DESCRIPTION
## Problem

We're always redirecting to `/dashboard` when doing a full reload.

## Solution

We actually only want to redirect to `/dashboard` when trying to access the completed onboarding wizard. An added path check prevents unnecessary redirects.

## Changes Made

- Add check if we're actually trying to access the onboarding wizard and only then redirect based on completion status!

## How to Test

Do a full reload on any page. You should stay on that page instead of getting redirected to `/dashboard`

## Screenshots

Not needed

## Notes

None

## Checklist

- [x] Code follows the <a href="https://github.com/tailwarden/komiser/blob/master/CONTRIBUTING.md">contributing</a> guidelines
- [x] Changes have been thoroughly tested
- [x] <a href="https://github.com/tailwarden/docs.komiser.io">Documentation</a> has been updated, if necessary
- [x] Any dependencies have been added to the project, if necessary

## Reviewers

Code owners

