### PR TITLE
Feature/550 lambda eventsourcemapping

### DIFF
--- a/providers/aws/aws.go
+++ b/providers/aws/aws.go
@@ -39,6 +39,7 @@ func listOfSupportedServices() []providers.FetchDataFunction {
 		ec2.Instances,
 		ec2.ElasticIps,
 		lambda.Functions,
+		lambda.EventSourceMappings,
 		ec2.Acls,
 		ec2.Subnets,
 		ec2.SecurityGroups,

--- a/providers/aws/lambda/eventsourcemappings.go
+++ b/providers/aws/lambda/eventsourcemappings.go
@@ -37,7 +37,7 @@ func EventSourceMappings(ctx context.Context, client providers.ProviderClient) (
                         Name:       *mapping.UUID,
                         Cost:       0.0,
                         Metadata: map[string]string{
-                                "lambda": *mapping.EventSourceArn,
+                                "lambda": *mapping.FunctionArn,
                                 "source": *mapping.EventSourceArn,
                         },
                         FetchedAt: time.Now(),

--- a/providers/aws/lambda/eventsourcemappings.go
+++ b/providers/aws/lambda/eventsourcemappings.go
@@ -1,0 +1,56 @@
+package lambda
+
+import (
+        "context"
+        "fmt"
+        "strings"
+        "time"
+
+        "github.com/aws/aws-sdk-go-v2/service/lambda"
+        log "github.com/sirupsen/logrus"
+        "github.com/tailwarden/komiser/models"
+        "github.com/tailwarden/komiser/providers"
+)
+
+func EventSourceMappings(ctx context.Context, client providers.ProviderClient) ([]models.Resource, error) {
+        var config lambda.ListEventSourceMappingsInput
+        resources := make([]models.Resource, 0)
+        lambdaClient := lambda.NewFromConfig(*client.AWSClient)
+
+        result, err := lambdaClient.ListEventSourceMappings(context.Background(), &config)
+        if err != nil {
+                log.Errorf("ERROR: Failed to fetch EventSourceMappings: %v", err)
+                return resources, err
+        }
+
+        for _, mapping := range result.EventSourceMappings {
+
+                lambdaNameSplit := strings.Split(*mapping.FunctionArn, ":")
+                lambdaName := lambdaNameSplit[len(lambdaNameSplit)-1]
+
+                resources = append(resources, models.Resource{
+                        Provider:   "AWS",
+                        Account:    client.Name,
+                        Service:    "EventSourceMapping",
+                        ResourceId: *mapping.UUID,
+                        Region:     client.AWSClient.Region,
+                        Name:       *mapping.UUID,
+                        Cost:       0.0,
+                        Metadata: map[string]string{
+                                "lambda": *mapping.EventSourceArn,
+                                "source": *mapping.EventSourceArn,
+                        },
+                        FetchedAt: time.Now(),
+                        Link:      fmt.Sprintf("https://%s.console.aws.amazon.com/lambda/home?region=%s#/functions/%s", client.AWSClient.Region, client.AWSClient.Region, lambdaName),
+                })
+        }
+
+        log.WithFields(log.Fields{
+                "provider":  "AWS",
+                "account":   client.Name,
+                "region":    client.AWSClient.Region,
+                "service":   "EventSourceMapping",
+                "resources": len(resources),
+        }).Info("Fetched resources")
+        return resources, nil
+}

--- a/providers/aws/lambda/eventsourcemappings.go
+++ b/providers/aws/lambda/eventsourcemappings.go
@@ -5,45 +5,56 @@ import (
         "fmt"
         "strings"
         "time"
-        
+
         log "github.com/sirupsen/logrus"
-        
+
+        "github.com/aws/aws-sdk-go-v2/aws"
         "github.com/aws/aws-sdk-go-v2/service/lambda"
         "github.com/tailwarden/komiser/models"
         "github.com/tailwarden/komiser/providers"
 )
 
 func EventSourceMappings(ctx context.Context, client providers.ProviderClient) ([]models.Resource, error) {
-        var config lambda.ListEventSourceMappingsInput
         resources := make([]models.Resource, 0)
         lambdaClient := lambda.NewFromConfig(*client.AWSClient)
-
-        result, err := lambdaClient.ListEventSourceMappings(context.Background(), &config)
-        if err != nil {
-                log.Errorf("ERROR: Failed to fetch EventSourceMappings: %v", err)
-                return resources, err
+        mappingsPerPage := aws.Int32(50)
+        params := &lambda.ListEventSourceMappingsInput{
+                MaxItems: mappingsPerPage,
         }
 
-        for _, mapping := range result.EventSourceMappings {
+        paginator := lambda.NewListEventSourceMappingsPaginator(lambdaClient, params, func(options *lambda.ListEventSourceMappingsPaginatorOptions) {
+                options.Limit = *mappingsPerPage
+        })
 
-                lambdaNameSplit := strings.Split(*mapping.FunctionArn, ":")
-                lambdaName := lambdaNameSplit[len(lambdaNameSplit)-1]
+        for paginator.HasMorePages() {
+                
+                output, err := paginator.NextPage(context.Background())
+                if err != nil {
+                        log.Errorf("ERROR: Error occurred while retrieving EventSourceMappings page: %v", err)
+                        return resources, err
+                }
 
-                resources = append(resources, models.Resource{
-                        Provider:   "AWS",
-                        Account:    client.Name,
-                        Service:    "EventSourceMapping",
-                        ResourceId: *mapping.UUID,
-                        Region:     client.AWSClient.Region,
-                        Name:       *mapping.UUID,
-                        Cost:       0.0,
-                        Metadata: map[string]string{
-                                "lambda": *mapping.FunctionArn,
-                                "source": *mapping.EventSourceArn,
-                        },
-                        FetchedAt: time.Now(),
-                        Link:      fmt.Sprintf("https://%s.console.aws.amazon.com/lambda/home?region=%s#/functions/%s", client.AWSClient.Region, client.AWSClient.Region, lambdaName),
-                })
+                for _, mapping := range output.EventSourceMappings {
+
+                        lambdaNameSplit := strings.Split(*mapping.FunctionArn, ":")
+                        lambdaName := lambdaNameSplit[len(lambdaNameSplit)-1]
+
+                        resources = append(resources, models.Resource{
+                                Provider:   "AWS",
+                                Account:    client.Name,
+                                Service:    "EventSourceMapping",
+                                ResourceId: *mapping.UUID,
+                                Region:     client.AWSClient.Region,
+                                Name:       *mapping.UUID,
+                                Cost:       0.0,
+                                Metadata: map[string]string{
+                                        "lambda": *mapping.FunctionArn,
+                                        "source": *mapping.EventSourceArn,
+                                },
+                                FetchedAt: time.Now(),
+                                Link:      fmt.Sprintf("https://%s.console.aws.amazon.com/lambda/home?region=%s#/functions/%s", client.AWSClient.Region, client.AWSClient.Region, lambdaName),
+                        })
+                }
         }
 
         log.WithFields(log.Fields{

--- a/providers/aws/lambda/eventsourcemappings.go
+++ b/providers/aws/lambda/eventsourcemappings.go
@@ -5,9 +5,10 @@ import (
         "fmt"
         "strings"
         "time"
-
-        "github.com/aws/aws-sdk-go-v2/service/lambda"
+        
         log "github.com/sirupsen/logrus"
+        
+        "github.com/aws/aws-sdk-go-v2/service/lambda"
         "github.com/tailwarden/komiser/models"
         "github.com/tailwarden/komiser/providers"
 )

--- a/providers/aws/lambda/eventsourcemappings.go
+++ b/providers/aws/lambda/eventsourcemappings.go
@@ -28,7 +28,7 @@ func EventSourceMappings(ctx context.Context, client providers.ProviderClient) (
 
         for paginator.HasMorePages() {
                 
-                output, err := paginator.NextPage(context.Background())
+                output, err := paginator.NextPage(ctx)
                 if err != nil {
                         log.Errorf("ERROR: Error occurred while retrieving EventSourceMappings page: %v", err)
                         return resources, err


### PR DESCRIPTION
## Problem

Collector for Lambda collector not present

## Solution

Add collector for AWS Lambda EventSourceMapping

## Changes Made

- Added function `EventSourceMappings` in `providers/aws/lambda`
- Add function to return array in `listOfSupportedServices` in `providers/aws/`

## How to Test

In your AWS account, create a lambda function that has an SQS queue set as a trigger. With Komiser properly 
configured to your account, you should see a `EventSourceMapping` resource appear.

## Screenshots
![image](https://github.com/tailwarden/komiser/assets/62848920/a4da42ca-3ae2-40b6-a709-3009ccc97ec8)

## Notes

- EventSourceMappings don't have names so the ID is used instead
- similarly they don't have tags (afaik)
- Do not incur any costs
- link goes to the corresponding lambda function

## Checklist

- [x] Code follows the <a href="https://github.com/tailwarden/komiser/blob/master/CONTRIBUTING.md">contributing</a> guidelines
- [x] Changes have been thoroughly tested
- [ ] <a href="https://github.com/tailwarden/docs.komiser.io">Documentation</a> has been updated, if necessary
- [x] Any dependencies have been added to the project, if necessary

## Reviewers


