### PR TITLE
Adding Kinesis Data Streams to the list of supported resources

### DIFF
--- a/docs/configuration/cloud-providers/aws.mdx
+++ b/docs/configuration/cloud-providers/aws.mdx
@@ -32,6 +32,7 @@ sidebar_label: Amazon Web Services
   - IAM policies
   - IAM roles
   - IAM SAML providers
+  - Kinesis Data Streams
   - KMS keys
   - Lambda functions
   - RDS clusters


### PR DESCRIPTION
## Problem

This PR is about the following feature:
https://github.com/tailwarden/komiser/issues/548

## Solution

As far as I can see Kinesis Data Streams are already supported.  
The only missing part was having it documented in the supported resources.

## Changes Made

- Only updated the documentation to add KDS to the list of supported resources.

## How to Test

I tested by creating a Kinesis Data Stream in my AWS account.  
Komiser was able to find it and display it.

## Screenshots

![image](https://github.com/tailwarden/komiser/assets/1489214/64684835-6743-40ba-875f-c6cfa734d636)

## Notes

n/a

## Checklist

- [x] Code follows the <a href="https://github.com/tailwarden/komiser/blob/master/CONTRIBUTING.md">contributing</a> guidelines
- [x] Changes have been thoroughly tested
- [x] <a href="https://github.com/tailwarden/docs.komiser.io">Documentation</a> has been updated, if necessary
- [x] Any dependencies have been added to the project, if necessary

## Reviewers

@jakepage91

