### PR TITLE
add cost for k8s services

### DIFF
--- a/providers/k8s/core/services.go
+++ b/providers/k8s/core/services.go
@@ -8,6 +8,7 @@ import (
 
 	. "github.com/tailwarden/komiser/models"
 	"github.com/tailwarden/komiser/providers"
+	oc "github.com/tailwarden/komiser/providers/k8s/opencost"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
@@ -15,6 +16,14 @@ func Services(ctx context.Context, client providers.ProviderClient) ([]Resource,
 	resources := make([]Resource, 0)
 
 	var config metav1.ListOptions
+
+	opencostEnabled := true
+	serviceCost, err := oc.GetOpencostInfo(client.K8sClient.OpencostBaseUrl, "service")
+	if err != nil {
+		log.Errorf("ERROR: Couldn't get service info from OpenCost: %v", err)
+		log.Warn("Opencost disabled")
+		opencostEnabled = false
+	}
 
 	for {
 		res, err := client.K8sClient.Client.CoreV1().Services("").List(ctx, config)
@@ -32,6 +41,11 @@ func Services(ctx context.Context, client providers.ProviderClient) ([]Resource,
 				})
 			}
 
+			cost := 0.0
+			if opencostEnabled {
+				cost = serviceCost[service.Name].TotalCost
+			}
+
 			resources = append(resources, Resource{
 				Provider:   "Kubernetes",
 				Account:    client.Name,
@@ -39,7 +53,7 @@ func Services(ctx context.Context, client providers.ProviderClient) ([]Resource,
 				ResourceId: string(service.UID),
 				Name:       service.Name,
 				Region:     service.Namespace,
-				Cost:       0,
+				Cost:       cost,
 				CreatedAt:  service.CreationTimestamp.Time,
 				FetchedAt:  time.Now(),
 				Tags:       tags,


### PR DESCRIPTION
## Problem https://github.com/tailwarden/komiser/issues/1036

Currently komiser doesn't provide cost for k8s services. Its always 0. This PR fixes that. Implementation is similar to others, using opencost to generate the cost for services.

## Solution


## Changes Made

- Added GetOpencostInfo for service


## Screenshots

<img width="1512" alt="Screenshot 2023-10-06 at 12 18 45 PM" src="https://github.com/tailwarden/komiser/assets/7694806/7f259400-b874-462c-9c4c-d0a672a231dc">



## Checklist

- [X] Code follows the <a href="https://github.com/tailwarden/komiser/blob/master/CONTRIBUTING.md">contributing</a> guidelines
- [X] Changes have been thoroughly tested
- [ ] <a href="https://github.com/tailwarden/docs.komiser.io">Documentation</a> has been updated, if necessary
- [ ] Any dependencies have been added to the project, if necessary


