### PR TITLE
doc: path is a string and should use double quotes

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -204,7 +204,7 @@ An example configuration entry for configuring a Google Cloud account in the **`
 [[gcp]]
 name="production"
 source="ENVIRONMENT_VARIABLES"
-# path=./path/to/credentials/file specify if 'CREDENTIALS_FILE' is used as source
+# path="./path/to/credentials/file" specify if 'CREDENTIALS_FILE' is used as source
 profile="production"
 ```
 

--- a/docs/configuration/cloud-providers/aws.mdx
+++ b/docs/configuration/cloud-providers/aws.mdx
@@ -97,19 +97,19 @@ Add to config.toml file
 [[aws]]
 name="sandbox"
 source="CREDENTIALS_FILE"
-path=./path/to/credentials/file
+path="./path/to/credentials/file"
 profile="default"
 
 [[aws]]
 name="staging"
 source="CREDENTIALS_FILE"
-path=./path/to/credentials/file
+path="./path/to/credentials/file"
 profile="staging-account"
 
 [[gcp]]
 name="production"
 source="ENVIRONMENT_VARIABLES"
-# path=./path/to/credentials/file specify if CREDENTIALS_FILE is used
+# path="./path/to/credentials/file" specify if CREDENTIALS_FILE is used
 profile="production"
 
 [postgres]
@@ -136,7 +136,7 @@ profile="production"
 [[aws]]
 name="sandbox"
 source="CREDENTIALS_FILE"
-path=./path/to/credentials/file
+path="./path/to/credentials/file"
 profile="default"
 ```
 ### Credentials file

--- a/docs/getting-started/quickstart.mdx
+++ b/docs/getting-started/quickstart.mdx
@@ -56,19 +56,19 @@ The reason for this external data persistence is to improve the filtering, sorti
 [[aws]]
 name="sandbox"
 source="CREDENTIALS_FILE"
-path=./path/to/credentials/file
+path="./path/to/credentials/file"
 profile="default"
 
 [[aws]]
 name="staging"
 source="CREDENTIALS_FILE"
-path=./path/to/credentials/file
+path="./path/to/credentials/file"
 profile="staging-account"
 
 [[gcp]]
 name="production"
 source="ENVIRONMENT_VARIABLES"
-# path=./path/to/credentials/file specify if CREDENTIALS_FILE is used
+# path="./path/to/credentials/file" specify if CREDENTIALS_FILE is used
 profile="production"
 
 [postgres]


### PR DESCRIPTION
## Problem

I believe there is a slight error in the documentation.  
The path is a string and should use double quotes.  
Otherwise we end up with this error:
<img width="806" alt="image" src="https://github.com/tailwarden/komiser/assets/1489214/475ad73e-4c4f-4cc9-b5e5-84d77d137a8d">

## Solution

Updated the documentation to use double quotes.

## Changes Made

- Updated the documentation to use double quotes.

## How to Test

This is a documentation change, so no tests are available.

## Checklist

- [ ] Code follows the <a href="https://github.com/tailwarden/komiser/blob/master/CONTRIBUTING.md">contributing</a> guidelines
- [ ] Changes have been thoroughly tested
- [ ] <a href="https://github.com/tailwarden/docs.komiser.io">Documentation</a> has been updated, if necessary
- [ ] Any dependencies have been added to the project, if necessary

## Reviewers

@mlabouardy
@jakepage91 

