### PR TITLE
chore: drop deprecated ioutil

### DIFF
--- a/internal/config/load.go
+++ b/internal/config/load.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"io/ioutil"
 	"log"
 	"net/http"
 	"os"
@@ -46,7 +45,7 @@ func loadConfigFromFile(path string) (*Config, error) {
 		return nil, fmt.Errorf("no such file %s", filename)
 	}
 
-	yamlFile, err := ioutil.ReadFile(filename)
+	yamlFile, err := os.ReadFile(filename)
 	if err != nil {
 		return nil, err
 	}
@@ -436,7 +435,7 @@ func Load(configPath string, telemetry bool, analytics utils.Analytics, db *bun.
 
 			accounts = append(accounts, cloudAccount)
 
-			data, err := ioutil.ReadFile(account.ServiceAccountKeyPath)
+			data, err := os.ReadFile(account.ServiceAccountKeyPath)
 			if err != nil {
 				log.Fatal(err)
 			}

--- a/providers/gcp/compute/instances_test.go
+++ b/providers/gcp/compute/instances_test.go
@@ -3,7 +3,7 @@ package compute
 import (
 	"context"
 	"fmt"
-	"io/ioutil"
+	"os"
 	"testing"
 
 	"github.com/tailwarden/komiser/providers"
@@ -13,7 +13,7 @@ import (
 func TestInstances(t *testing.T) {
 	t.Skip("Only for local development because it is using a Google Cloud connection")
 	// Replace the empty string with a SA or credentials file location
-	data, err := ioutil.ReadFile("")
+	data, err := os.ReadFile("")
 	if err != nil {
 		t.Fatal(err)
 	}


### PR DESCRIPTION
## Problem

With the two proposals accepted (https://github.com/golang/go/issues/42026 and https://github.com/golang/go/issues/40025), the package io/ioutil has been deprecated
 since Go 1.16
## Solution

This PR removes remaining traces of it.

## Changes Made

- Replaced ioutil with either os or io package

## How to Test

komiser start --config config.toml

## Notes

This is just groundwork for getting the linter in

## Checklist

- [X] Code follows the <a href="https://github.com/tailwarden/komiser/blob/master/CONTRIBUTING.md">contributing</a> guidelines
- [X] Changes have been thoroughly tested
- [ ] <a href="https://github.com/tailwarden/docs.komiser.io">Documentation</a> has been updated, if necessary
- [ ] Any dependencies have been added to the project, if necessary


