### PR TITLE
feat: support k8s controllers

### DIFF
--- a/providers/k8s/core/daemonsets.go
+++ b/providers/k8s/core/daemonsets.go
@@ -1,0 +1,77 @@
+package core
+
+import (
+	"context"
+	"time"
+
+	log "github.com/sirupsen/logrus"
+
+	"github.com/tailwarden/komiser/models"
+	"github.com/tailwarden/komiser/providers"
+	oc "github.com/tailwarden/komiser/providers/k8s/opencost"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func DaemonSets(ctx context.Context, client providers.ProviderClient) ([]models.Resource, error) {
+	resources := make([]models.Resource, 0)
+
+	var config metav1.ListOptions
+
+	opencostEnabled := true
+	daemonsetsCost, err := oc.GetOpencostInfo(client.K8sClient.OpencostBaseUrl, "daemonset")
+	if err != nil {
+		log.Errorf("ERROR: Couldn't get daemonsets info from OpenCost: %v", err)
+		log.Warn("Opencost disabled")
+		opencostEnabled = false
+	}
+
+	for {
+		res, err := client.K8sClient.Client.AppsV1().DaemonSets("").List(ctx, config)
+		if err != nil {
+			return nil, err
+		}
+
+		for _, daemonset := range res.Items {
+			tags := make([]models.Tag, 0)
+
+			for key, value := range daemonset.Labels {
+				tags = append(tags, models.Tag{
+					Key:   key,
+					Value: value,
+				})
+			}
+
+			cost := 0.0
+			if opencostEnabled {
+				cost = daemonsetsCost[daemonset.Name].TotalCost
+			}
+
+			resources = append(resources, models.Resource{
+				Provider:   "Kubernetes",
+				Account:    client.Name,
+				Service:    "Daemonset",
+				ResourceId: string(daemonset.UID),
+				Name:       daemonset.Name,
+				Region:     daemonset.Namespace,
+				Cost:       cost,
+				CreatedAt:  daemonset.CreationTimestamp.Time,
+				FetchedAt:  time.Now(),
+				Tags:       tags,
+			})
+		}
+
+		if res.GetContinue() == "" {
+			break
+		}
+
+		config.Continue = res.GetContinue()
+	}
+
+	log.WithFields(log.Fields{
+		"provider":  "Kubernetes",
+		"account":   client.Name,
+		"service":   "Daemonset",
+		"resources": len(resources),
+	}).Info("Fetched resources")
+	return resources, nil
+}

--- a/providers/k8s/core/jobs.go
+++ b/providers/k8s/core/jobs.go
@@ -1,0 +1,77 @@
+package core
+
+import (
+	"context"
+	"time"
+
+	log "github.com/sirupsen/logrus"
+
+	"github.com/tailwarden/komiser/models"
+	"github.com/tailwarden/komiser/providers"
+	oc "github.com/tailwarden/komiser/providers/k8s/opencost"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func Jobs(ctx context.Context, client providers.ProviderClient) ([]models.Resource, error) {
+	resources := make([]models.Resource, 0)
+
+	var config metav1.ListOptions
+
+	opencostEnabled := true
+	jobsCost, err := oc.GetOpencostInfo(client.K8sClient.OpencostBaseUrl, "job")
+	if err != nil {
+		log.Errorf("ERROR: Couldn't get jobs info from OpenCost: %v", err)
+		log.Warn("Opencost disabled")
+		opencostEnabled = false
+	}
+
+	for {
+		res, err := client.K8sClient.Client.BatchV1().Jobs("").List(ctx, config)
+		if err != nil {
+			return nil, err
+		}
+
+		for _, job := range res.Items {
+			tags := make([]models.Tag, 0)
+
+			for key, value := range job.Labels {
+				tags = append(tags, models.Tag{
+					Key:   key,
+					Value: value,
+				})
+			}
+
+			cost := 0.0
+			if opencostEnabled {
+				cost = jobsCost[job.Name].TotalCost
+			}
+
+			resources = append(resources, models.Resource{
+				Provider:   "Kubernetes",
+				Account:    client.Name,
+				Service:    "Job",
+				ResourceId: string(job.UID),
+				Name:       job.Name,
+				Region:     job.Namespace,
+				Cost:       cost,
+				CreatedAt:  job.CreationTimestamp.Time,
+				FetchedAt:  time.Now(),
+				Tags:       tags,
+			})
+		}
+
+		if res.GetContinue() == "" {
+			break
+		}
+
+		config.Continue = res.GetContinue()
+	}
+
+	log.WithFields(log.Fields{
+		"provider":  "Kubernetes",
+		"account":   client.Name,
+		"service":   "DaemonSet",
+		"resources": len(resources),
+	}).Info("Fetched resources")
+	return resources, nil
+}

--- a/providers/k8s/k8s.go
+++ b/providers/k8s/k8s.go
@@ -24,6 +24,7 @@ func listOfSupportedServices() []providers.FetchDataFunction {
 		core.Namespaces,
 		core.DaemonSets,
 		core.StatefulSets,
+		core.Jobs,
 	}
 }
 

--- a/providers/k8s/k8s.go
+++ b/providers/k8s/k8s.go
@@ -22,6 +22,8 @@ func listOfSupportedServices() []providers.FetchDataFunction {
 		core.ServiceAccounts,
 		core.Nodes,
 		core.Namespaces,
+		core.DaemonSets,
+		core.StatefulSets,
 	}
 }
 


### PR DESCRIPTION
## Problem

Calculating costs for multiple kubernetes controllers were yet to be added.

## Solution

Adding support for kubernetes controllers cost calculation.

## Changes Made

Added support for:
- `statefulsets.go`
- `jobs.go`
- `daemonsets.go`

## Notes

Fixes https://github.com/tailwarden/komiser/issues/1037

## Checklist

- [ ] Code follows the <a href="https://github.com/tailwarden/komiser/blob/master/CONTRIBUTING.md">contributing</a> guidelines
- [ ] Changes have been thoroughly tested
- [ ] <a href="https://github.com/tailwarden/docs.komiser.io">Documentation</a> has been updated, if necessary
- [ ] Any dependencies have been added to the project, if necessary

## Reviewers

@[username of the reviewer]

