### PR TITLE
feat: add support of Kinesis EFO Consumers

### DIFF
--- a/docs/configuration/cloud-providers/aws.mdx
+++ b/docs/configuration/cloud-providers/aws.mdx
@@ -33,6 +33,7 @@ sidebar_label: Amazon Web Services
   - IAM roles
   - IAM SAML providers
   - Kinesis Data Streams
+  - Kinesis EFO Consumers
   - KMS keys
   - Lambda functions
   - RDS clusters

--- a/mocks/kinesis.go
+++ b/mocks/kinesis.go
@@ -1,0 +1,20 @@
+package mocks
+
+import (
+	"context"
+
+	"github.com/aws/aws-sdk-go-v2/service/kinesis"
+	"github.com/stretchr/testify/mock"
+)
+
+type KinesisClient struct {
+	mock.Mock
+}
+
+func (_m *KinesisClient) ListStreamConsumers(ctx context.Context, params *kinesis.ListStreamConsumersInput, optFns ...func(*kinesis.Options)) (*kinesis.ListStreamConsumersOutput, error) {
+	ret := _m.Called(ctx, params, optFns)
+	if ret.Get(1) == nil {
+		return ret.Get(0).(*kinesis.ListStreamConsumersOutput), nil
+	}
+	return nil, ret.Get(1).(error)
+}

--- a/policy.json
+++ b/policy.json
@@ -55,6 +55,7 @@
 				"iam:ListSAMLProviders",
 				"iam:ListSAMLProviderTags",
 				"kinesis:ListStreams",
+				"kinesis:ListStreamConsumers",
 				"kms:ListKeys",
 				"kms:ListResourceTags",
 				"kms:DescribeKey",

--- a/providers/aws/kinesis/streams.go
+++ b/providers/aws/kinesis/streams.go
@@ -42,7 +42,7 @@ func Streams(ctx context.Context, client ProviderClient) ([]Resource, error) {
 				FetchedAt:  time.Now(),
 				Link:       fmt.Sprintf("https://%s.console.aws.amazon.com/kinesis/home?region=%s#/streams/details/%s", client.AWSClient.Region, client.AWSClient.Region, *stream.StreamName),
 			})
-			consumers, err := getStreamConsumers(kinesisClient, stream, client.Name, client.AWSClient.Region)
+			consumers, err := getStreamConsumers(ctx, kinesisClient, stream, client.Name, client.AWSClient.Region)
 			if err != nil {
 				return resources, err
 			}
@@ -67,14 +67,14 @@ func Streams(ctx context.Context, client ProviderClient) ([]Resource, error) {
 	return resources, nil
 }
 
-func getStreamConsumers(kinesisClient KinesisClient, stream types.StreamSummary, clientName, region string) ([]Resource, error) {
+func getStreamConsumers(ctx context.Context, kinesisClient KinesisClient, stream types.StreamSummary, clientName, region string) ([]Resource, error) {
 	resources := make([]Resource, 0)
 	config := kinesis.ListStreamConsumersInput{
 		StreamARN: aws.String(aws.ToString(stream.StreamARN)),
 	}
 
 	for {
-		output, err := kinesisClient.ListStreamConsumers(context.Background(), &config)
+		output, err := kinesisClient.ListStreamConsumers(ctx, &config)
 		if err != nil {
 			return resources, err
 		}

--- a/providers/aws/kinesis/streams_test.go
+++ b/providers/aws/kinesis/streams_test.go
@@ -1,6 +1,7 @@
 package kinesis
 
 import (
+	"context"
 	"fmt"
 	"testing"
 	"time"
@@ -136,10 +137,12 @@ func Test_getStreamConsumers(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			ctx := context.Background()
+
 			kinesisClient := &mocks.KinesisClient{}
 			tt.setupMock(kinesisClient)
 
-			got, err := getStreamConsumers(kinesisClient, tt.stream, tt.clientName, tt.region)
+			got, err := getStreamConsumers(ctx, kinesisClient, tt.stream, tt.clientName, tt.region)
 			if (err != nil) != tt.wantErr {
 				t.Errorf("getStreamConsumers() error = %v, wantErr %v", err, tt.wantErr)
 				return

--- a/providers/aws/kinesis/streams_test.go
+++ b/providers/aws/kinesis/streams_test.go
@@ -1,0 +1,164 @@
+package kinesis
+
+import (
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/kinesis"
+	"github.com/aws/aws-sdk-go-v2/service/kinesis/types"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+	"github.com/tailwarden/komiser/mocks"
+	. "github.com/tailwarden/komiser/models"
+)
+
+func Test_getStreamConsumers(t *testing.T) {
+	tests := []struct {
+		name       string
+		stream     types.StreamSummary
+		setupMock  func(m *mocks.KinesisClient)
+		clientName string
+		region     string
+		want       []Resource
+		wantErr    bool
+	}{
+		{
+			name: "Should return one EFO consumer",
+			stream: types.StreamSummary{
+				StreamARN:  aws.String("arn:aws:kinesis:us-east-1:0123456789:stream/kinesis-data-stream"),
+				StreamName: aws.String("kinesis-data-stream"),
+			},
+			setupMock: func(m *mocks.KinesisClient) {
+				m.On("ListStreamConsumers", mock.Anything, mock.Anything, mock.Anything).Return(&kinesis.ListStreamConsumersOutput{
+					Consumers: []types.Consumer{
+						{
+							ConsumerARN:               aws.String("arn:aws:kinesis:us-east-1:0123456789:stream/kinesis-data-stream/consumer/kinesis-efo-consumer:1234567890"),
+							ConsumerCreationTimestamp: aws.Time(time.UnixMilli(1234567890)),
+							ConsumerName:              aws.String("kinesis-efo-consumer"),
+							ConsumerStatus:            types.ConsumerStatusActive,
+						},
+					},
+				}, nil).Once()
+			},
+			clientName: "sandbox",
+			region:     "us-east-1",
+			want: []Resource{
+				{
+					Provider:   "AWS",
+					Account:    "sandbox",
+					Service:    "Kinesis EFO Consumer",
+					ResourceId: "arn:aws:kinesis:us-east-1:0123456789:stream/kinesis-data-stream/consumer/kinesis-efo-consumer:1234567890",
+					Region:     "us-east-1",
+					Name:       "kinesis-efo-consumer",
+					Cost:       0,
+					CreatedAt:  time.UnixMilli(1234567890),
+					FetchedAt:  time.Now(),
+					Link:       "https://us-east-1.console.aws.amazon.com/kinesis/home?region=us-east-1#/streams/details/kinesis-data-stream/registeredConsumers/kinesis-efo-consumer",
+				},
+			},
+			wantErr: false,
+		},
+		{
+			name: "Should paginate using next token",
+			stream: types.StreamSummary{
+				StreamARN:  aws.String("arn:aws:kinesis:us-east-1:0123456789:stream/kinesis-data-stream"),
+				StreamName: aws.String("kinesis-data-stream"),
+			},
+			setupMock: func(m *mocks.KinesisClient) {
+				m.On("ListStreamConsumers", mock.Anything, mock.Anything, mock.Anything).Return(&kinesis.ListStreamConsumersOutput{
+					NextToken: aws.String("next-token"),
+					Consumers: []types.Consumer{
+						{
+							ConsumerARN:               aws.String("arn:aws:kinesis:us-east-1:0123456789:stream/kinesis-data-stream/consumer/kinesis-efo-consumer-1:1234567890"),
+							ConsumerCreationTimestamp: aws.Time(time.UnixMilli(1234567890)),
+							ConsumerName:              aws.String("kinesis-efo-consumer-1"),
+							ConsumerStatus:            types.ConsumerStatusActive,
+						},
+					},
+				}, nil).Once()
+				m.On("ListStreamConsumers", mock.Anything, mock.Anything, mock.Anything).Return(&kinesis.ListStreamConsumersOutput{
+					Consumers: []types.Consumer{
+						{
+							ConsumerARN:               aws.String("arn:aws:kinesis:us-east-1:0123456789:stream/kinesis-data-stream/consumer/kinesis-efo-consumer-2:1234567890"),
+							ConsumerCreationTimestamp: aws.Time(time.UnixMilli(1234567890)),
+							ConsumerName:              aws.String("kinesis-efo-consumer-2"),
+							ConsumerStatus:            types.ConsumerStatusActive,
+						},
+					},
+				}, nil).Once()
+			},
+			clientName: "sandbox",
+			region:     "us-east-1",
+			want: []Resource{
+				{
+					Provider:   "AWS",
+					Account:    "sandbox",
+					Service:    "Kinesis EFO Consumer",
+					ResourceId: "arn:aws:kinesis:us-east-1:0123456789:stream/kinesis-data-stream/consumer/kinesis-efo-consumer-1:1234567890",
+					Region:     "us-east-1",
+					Name:       "kinesis-efo-consumer-1",
+					Cost:       0,
+					CreatedAt:  time.UnixMilli(1234567890),
+					FetchedAt:  time.Now(),
+					Link:       "https://us-east-1.console.aws.amazon.com/kinesis/home?region=us-east-1#/streams/details/kinesis-data-stream/registeredConsumers/kinesis-efo-consumer-1",
+				},
+				{
+					Provider:   "AWS",
+					Account:    "sandbox",
+					Service:    "Kinesis EFO Consumer",
+					ResourceId: "arn:aws:kinesis:us-east-1:0123456789:stream/kinesis-data-stream/consumer/kinesis-efo-consumer-2:1234567890",
+					Region:     "us-east-1",
+					Name:       "kinesis-efo-consumer-2",
+					Cost:       0,
+					CreatedAt:  time.UnixMilli(1234567890),
+					FetchedAt:  time.Now(),
+					Link:       "https://us-east-1.console.aws.amazon.com/kinesis/home?region=us-east-1#/streams/details/kinesis-data-stream/registeredConsumers/kinesis-efo-consumer-2",
+				},
+			},
+			wantErr: false,
+		},
+		{
+			name: "Should return error if error with kinesis client",
+			stream: types.StreamSummary{
+				StreamARN:  aws.String("arn:aws:kinesis:us-east-1:0123456789:stream/kinesis-data-stream"),
+				StreamName: aws.String("kinesis-data-stream"),
+			},
+			setupMock: func(m *mocks.KinesisClient) {
+				m.On("ListStreamConsumers", mock.Anything, mock.Anything, mock.Anything).Return(nil, fmt.Errorf("unit test error")).Once()
+			},
+			clientName: "sandbox",
+			region:     "us-east-1",
+			want:       []Resource{},
+			wantErr:    true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			kinesisClient := &mocks.KinesisClient{}
+			tt.setupMock(kinesisClient)
+
+			got, err := getStreamConsumers(kinesisClient, tt.stream, tt.clientName, tt.region)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("getStreamConsumers() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if len(got) != len(tt.want) {
+				t.Errorf("getStreamConsumers() incorrect lenght of resources got = %v, want %v", len(got), len(tt.want))
+			} else {
+				for i := range got {
+					assert.Equalf(t, tt.want[i].Link, got[i].Link, "incorrect Link for resources")
+					assert.Equalf(t, tt.want[i].Provider, got[i].Provider, "incorrect Provider for resources")
+					assert.Equalf(t, tt.want[i].Account, got[i].Account, "incorrect Account for resources")
+					assert.Equalf(t, tt.want[i].Service, got[i].Service, "incorrect Service for resources")
+					assert.Equalf(t, tt.want[i].ResourceId, got[i].ResourceId, "incorrect ResourceId for resources")
+					assert.Equalf(t, tt.want[i].Region, got[i].Region, "incorrect Region for resources")
+					assert.Equalf(t, tt.want[i].Name, got[i].Name, "incorrect Name for resources")
+					assert.Equalf(t, tt.want[i].Cost, got[i].Cost, "incorrect Cost for resources")
+				}
+			}
+			kinesisClient.AssertExpectations(t)
+		})
+	}
+}


### PR DESCRIPTION
## Problem

So far EFO consumers were note shown in the inventory.  
It could make sense to show them, because each EFO consumer incurs additional charges.

## Solution

Use the `ListStreamConsumers` method provide by AWS to least the consumers for each Kinesis Data Stream.

## Changes Made

- Modified `streams.go` so that EFO consumers are retrieved.
- Added unit tests with 100% coverage on the new code added.
- Added a mock for Kinesis Client to be used in unit tests
- Updated the IAM policy so that `kinesis:ListStreamConsumers` is allowed
- Updated the list of supported resources in the documentation

## How to Test

In order to test the changes you first need to create a Kinesis Data Stream.  
Then you need to register an EFO consumer, for instance using the AWS cli:
`aws kinesis register-stream-consumer --stream-arn arn:aws:kinesis:us-east-1:0123456789:stream/my-awesome-data-stream --consumer-name my-awesome-efo-consumer`

## Screenshots
![image](https://github.com/tailwarden/komiser/assets/1489214/10638cec-e9a7-45dc-b4b2-7863b6f927be)
![image](https://github.com/tailwarden/komiser/assets/1489214/19a1efe6-dfce-427c-ab4e-d2d10da6c54f)
![image](https://github.com/tailwarden/komiser/assets/1489214/c4452d4c-044f-44f6-b94a-a3f6f44e8e3d)

## Checklist

- [x] Code follows the <a href="https://github.com/tailwarden/komiser/blob/master/CONTRIBUTING.md">contributing</a> guidelines
- [x] Changes have been thoroughly tested
- [x] <a href="https://github.com/tailwarden/docs.komiser.io">Documentation</a> has been updated, if necessary
- [x] Any dependencies have been added to the project, if necessary

## Reviewers

@mlabouardy
@jakepage91 

