### PR TITLE
feat: add empty state for empty page filters apllied on resource expl…

### DIFF
--- a/dashboard/components/empty-state/EmptyState.tsx
+++ b/dashboard/components/empty-state/EmptyState.tsx
@@ -21,7 +21,8 @@ type Poses =
   | 'shirt'
   | 'whiteboard'
   | 'thinking'
-  | 'working';
+  | 'working'
+  | 'tablet';
 
 export type EmptyStateProps = {
   title: string;

--- a/dashboard/components/explorer/DependencyGraph.tsx
+++ b/dashboard/components/explorer/DependencyGraph.tsx
@@ -1,5 +1,5 @@
 /* eslint-disable react-hooks/exhaustive-deps */
-import React, { useState, memo } from 'react';
+import React, { useState, memo, useEffect } from 'react';
 import CytoscapeComponent from 'react-cytoscapejs';
 import Cytoscape, { EventObject } from 'cytoscape';
 import popper from 'cytoscape-popper';
@@ -11,6 +11,8 @@ import nodeHtmlLabel, {
 
 // @ts-ignore
 import COSEBilkent from 'cytoscape-cose-bilkent';
+
+import EmptyState from '@components/empty-state/EmptyState';
 
 import Tooltip from '@components/tooltip/Tooltip';
 import WarningIcon from '@components/icons/WarningIcon';
@@ -35,6 +37,8 @@ nodeHtmlLabel(Cytoscape.use(COSEBilkent));
 Cytoscape.use(popper);
 const DependencyGraph = ({ data }: DependencyGraphProps) => {
   const [initDone, setInitDone] = useState(false);
+
+  const dataIsEmpty: boolean = data.nodes.length === 0;
 
   // Type technically is Cytoscape.EdgeCollection but that throws an unexpected error
   const loopAnimation = (eles: any) => {
@@ -122,39 +126,55 @@ const DependencyGraph = ({ data }: DependencyGraphProps) => {
 
   return (
     <div className="relative h-full flex-1 bg-dependency-graph bg-[length:40px_40px]">
-      <CytoscapeComponent
-        className="h-full w-full"
-        elements={CytoscapeComponent.normalizeElements({
-          nodes: data.nodes,
-          edges: data.edges
-        })}
-        maxZoom={maxZoom}
-        minZoom={minZoom}
-        layout={graphLayoutConfig}
-        stylesheet={[
-          {
-            selector: 'node',
-            style: nodeStyeConfig
-          },
-          {
-            selector: 'edge',
-            style: edgeStyleConfig
-          },
-          {
-            selector: '.leaf',
-            style: leafStyleConfig
-          }
-        ]}
-        cy={(cy: Cytoscape.Core) => cyActionHandlers(cy)}
-      />
-      <div className="absolute bottom-0 left-0 flex gap-2 overflow-visible overflow-visible bg-black-100 text-black-400">
+      {dataIsEmpty ? (
+        <>
+          <div className="translate-y-[201px]">
+            <EmptyState
+              title="No results for this filter"
+              message="It seems like you have no cloud resources matching the filters you added"
+              mascotPose="tablet"
+            />
+          </div>
+        </>
+      ) : (
+        <>
+          <CytoscapeComponent
+            className="h-full w-full"
+            elements={CytoscapeComponent.normalizeElements({
+              nodes: data.nodes,
+              edges: data.edges
+            })}
+            maxZoom={maxZoom}
+            minZoom={minZoom}
+            layout={graphLayoutConfig}
+            stylesheet={[
+              {
+                selector: 'node',
+                style: nodeStyeConfig
+              },
+              {
+                selector: 'edge',
+                style: edgeStyleConfig
+              },
+              {
+                selector: '.leaf',
+                style: leafStyleConfig
+              }
+            ]}
+            cy={(cy: Cytoscape.Core) => cyActionHandlers(cy)}
+          />
+        </>
+      )}
+      <div className="absolute bottom-0 left-0 flex gap-2 overflow-visible bg-black-100 text-black-400">
         {data?.nodes?.length} Resources
-        <div className="relative">
-          <WarningIcon className="peer" height="16" width="16" />
-          <Tooltip bottom="xs" align="left" width="lg">
-            Only AWS resources are currently supported on the explorer.
-          </Tooltip>
-        </div>
+        {!dataIsEmpty && (
+          <div className="relative">
+            <WarningIcon className="peer" height="16" width="16" />
+            <Tooltip bottom="xs" align="left" width="lg">
+              Only AWS resources are currently supported on the explorer.
+            </Tooltip>
+          </div>
+        )}
       </div>
     </div>
   );

--- a/dashboard/package.json
+++ b/dashboard/package.json
@@ -7,6 +7,7 @@
     "build": "next build && next export",
     "start": "next start -p 3002",
     "lint": "next lint",
+    "format": "prettier --write \"**/*.{ts,tsx,json,css,scss,md}\"",
     "prepare": "cd .. && husky install dashboard/.husky",
     "storybook": "storybook dev -p 6006",
     "build-storybook": "storybook build",


### PR DESCRIPTION
## Problem
[Here is a Ticket](https://github.com/tailwarden/komiser/issues/1079)
Currently, when the results for the filters applied on the Resources Explorer page are empty, the page renders an empty canvas.

## Solution

Implemented the empty state covered on the designs so it's clear there are no results for the filters selected.

## Notes

[Any additional notes or information that you would like to share with the reviewers.]

## Checklist

- [x] Code follows the <a href="https://github.com/tailwarden/komiser/blob/master/CONTRIBUTING.md">contributing</a> guidelines
- [x] Changes have been thoroughly tested
- [ ] <a href="https://github.com/tailwarden/docs.komiser.io">Documentation</a> has been updated, if necessary
- [ ] Any dependencies have been added to the project, if necessary

## Reviewers
[@victorgaard]

