### PR TITLE
 #1089 Added nil check on associated KeyPair

### DIFF
--- a/providers/aws/ec2/instances.go
+++ b/providers/aws/ec2/instances.go
@@ -212,12 +212,14 @@ func getEC2Relations(inst *etype.Instance, resourceArn string) (rel []models.Lin
 	})
 
 	// Get associated Keypair
-	rel = append(rel, models.Link{
-		ResourceID: *inst.KeyName,
-		Name:       *inst.KeyName,
-		Type:       "Key Pair",
-		Relation:   "USES",
-	})
+	if inst.KeyName != nil {
+		rel = append(rel, models.Link{
+			ResourceID: *inst.KeyName,
+			Name:       *inst.KeyName,
+			Type:       "Key Pair",
+			Relation:   "USES",
+		})
+	}
 
 	// Get associated IAM roles
 	if inst.IamInstanceProfile != nil {


### PR DESCRIPTION
## Problem

[Click here to view the issue ticket](https://github.com/tailwarden/komiser/issues/1089)
Runtime Error: Invalid Memory Address or Nil Pointer Dereference during Fresh Install

## Solution
need nil check for instance key pair name. because we are using ec2 instance with Ec2 session managers. in this case we don't have an ec2 key pair for the instance.

## Changes Made
- Added nil Check on KeyPair checking

## How to Test
- create ec2 instance without key pair
- run the komiser and test it

## Screenshots
![komiser-keypair issue](https://github.com/tailwarden/komiser/assets/11912587/f131a613-9fdb-4c16-a119-aa139fd2f349)

## Notes

[Any additional notes or information that you would like to share with the reviewers.]

## Checklist

- [x] Code follows the <a href="https://github.com/tailwarden/komiser/blob/master/CONTRIBUTING.md">contributing</a> guidelines
- [x] Changes have been thoroughly tested
- [ ] <a href="https://github.com/tailwarden/docs.komiser.io">Documentation</a> has been updated, if necessary
- [ ] Any dependencies have been added to the project, if necessary

## Reviewers

@[username of the reviewer]

