### PR TITLE
fix: golangci lint

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,6 +1,5 @@
 name: Lint
-on:
-  push:
+on: pull_request
 
 jobs:
   lint:
@@ -8,10 +7,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
+
       - name: Setup go
         uses: actions/setup-go@v4
         with:
           go-version-file: go.mod
+      
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v3
         with:

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -18,3 +18,4 @@ jobs:
         with:
           args: --timeout=10m
           version: v1.54.2
+          skip-pkg-cache: true


### PR DESCRIPTION
## Problem

golangci-lint was had stopped running due to https://github.com/golangci/golangci-lint-action/issues/135
Also, it was running on `push` events instead of `pull_request` events

## Solution

skipping pkg cache

## Checklist

- [X] Code follows the <a href="https://github.com/tailwarden/komiser/blob/master/CONTRIBUTING.md">contributing</a> guidelines
- [X] Changes have been thoroughly tested
- [X] <a href="https://github.com/tailwarden/docs.komiser.io">Documentation</a> has been updated, if necessary
- [X] Any dependencies have been added to the project, if necessary
