### PR TITLE
feat: retrieve tags of Kinesis Data Streams

### DIFF
--- a/providers/aws/kinesis/streams.go
+++ b/providers/aws/kinesis/streams.go
@@ -41,6 +41,8 @@ func Streams(ctx context.Context, client ProviderClient) ([]Resource, error) {
 						Value: aws.ToString(t.Value),
 					})
 				}
+			} else {
+				log.Warn("Failed to fetch tags for kinesis streams")
 			}
 			resources = append(resources, Resource{
 				Provider:   "AWS",

--- a/providers/aws/kinesis/streams.go
+++ b/providers/aws/kinesis/streams.go
@@ -30,6 +30,18 @@ func Streams(ctx context.Context, client ProviderClient) ([]Resource, error) {
 		}
 
 		for _, stream := range output.StreamSummaries {
+			tags := make([]Tag, 0)
+			tagsResp, err := kinesisClient.ListTagsForStream(context.Background(), &kinesis.ListTagsForStreamInput{
+				StreamARN: stream.StreamARN,
+			})
+			if err == nil {
+				for _, t := range tagsResp.Tags {
+					tags = append(tags, Tag{
+						Key:   aws.ToString(t.Key),
+						Value: aws.ToString(t.Value),
+					})
+				}
+			}
 			resources = append(resources, Resource{
 				Provider:   "AWS",
 				Account:    client.Name,
@@ -40,6 +52,7 @@ func Streams(ctx context.Context, client ProviderClient) ([]Resource, error) {
 				Cost:       0,
 				CreatedAt:  *stream.StreamCreationTimestamp,
 				FetchedAt:  time.Now(),
+				Tags:       tags,
 				Link:       fmt.Sprintf("https://%s.console.aws.amazon.com/kinesis/home?region=%s#/streams/details/%s", client.AWSClient.Region, client.AWSClient.Region, *stream.StreamName),
 			})
 			consumers, err := getStreamConsumers(ctx, kinesisClient, stream, client.Name, client.AWSClient.Region)


### PR DESCRIPTION
## Problem

So far Kinesis Data Streams had no tags, which made them being displayed is the untagged resources section. 

## Solution

Call the function `ListTagsForStream()` to retrieve the list of tags for each stream.

## Changes Made

- Updated the `streams.go` file to retrieve the tags

## How to Test

Create a Kinesis Data Stream and assign some tags to it.

## Notes

Next I will probably tackle the cost calculations for Kinesis.

## Checklist

- [x] Code follows the <a href="https://github.com/tailwarden/komiser/blob/master/CONTRIBUTING.md">contributing</a> guidelines
- [x] Changes have been thoroughly tested
- [x] <a href="https://github.com/tailwarden/docs.komiser.io">Documentation</a> has been updated, if necessary
- [x] Any dependencies have been added to the project, if necessary

## Reviewers

@mlabouardy
@AvineshTripathi 

