### PR TITLE
feat: add reusable upload component to storybook (#1095)

### DIFF
--- a/dashboard/components/feedback-widget/FeedbackWidget.tsx
+++ b/dashboard/components/feedback-widget/FeedbackWidget.tsx
@@ -1,5 +1,4 @@
 import { useState, useRef, useCallback, memo, SyntheticEvent } from 'react';
-import { FileUploader } from 'react-drag-drop-files';
 // eslint-disable-next-line import/no-extraneous-dependencies
 import { toBlob } from 'html-to-image';
 import Image from 'next/image';
@@ -10,6 +9,7 @@ import settingsService from '@services/settingsService';
 import Button from '@components/button/Button';
 import useToast from '@components/toast/hooks/useToast';
 import Toast from '@components/toast/Toast';
+import Upload from '@components/upload/Upload';
 
 // We define the placeholder here for convenience
 // It's difficult to read when passed inline
@@ -29,9 +29,7 @@ Outcome
 const useFeedbackWidget = (defaultState: boolean = false) => {
   const [showFeedbackModel, setShowFeedbackModal] = useState(defaultState);
 
-  const FILE_TYPES = ['JPG', 'PNG', 'GIF', 'TXT', 'LOG', 'MP4', 'AVI', 'MOV'];
   const FEEDBACK_MODAL_ID = 'feedback-modal';
-  const MAX_FILE_SIZE_MB = 37;
 
   function openFeedbackModal() {
     setShowFeedbackModal(true);
@@ -151,7 +149,7 @@ const useFeedbackWidget = (defaultState: boolean = false) => {
       }
     }
 
-    function uploadFile(attachement: File) {
+    function uploadFile(attachement: File | null): void {
       setFileAttachement(attachement);
     }
 
@@ -198,7 +196,7 @@ const useFeedbackWidget = (defaultState: boolean = false) => {
                     <>
                       <div
                         onClick={() => takeScreenshot()}
-                        className="w-[50%] grow cursor-pointer rounded border-2 border-black-170 py-5 text-center text-xs transition hover:border-[#B6EAEA] hover:bg-black-100"
+                        className="flex-1 grow cursor-pointer rounded border-2 border-black-170 py-5 text-center text-xs transition hover:border-[#B6EAEA] hover:bg-black-100"
                       >
                         <svg
                           className="mb-2 inline-block"
@@ -249,189 +247,32 @@ const useFeedbackWidget = (defaultState: boolean = false) => {
                       </span>
                     </>
                   )}
-                  <FileUploader
-                    classes={
-                      fileAttachement === null
-                        ? `grow cursor-pointer rounded border-2 border-dashed border-black-170 py-5 text-center text-xs transition hover:border-[#B6EAEA] hover:bg-black-100 w-[50%]`
-                        : `grow min-h-full flex-1 rounded border-2 border-[#B6EAEA] text-center text-xs transition w-full`
-                    }
-                    disabled={
-                      fileAttachement !== null ||
-                      isSendingFeedback ||
-                      isTakingScreenCapture
-                    }
-                    handleChange={uploadFile}
-                    name="attachement"
-                    types={FILE_TYPES}
-                    fileOrFiles={fileAttachement}
-                    hoverTitle="drop here"
-                    maxSize={MAX_FILE_SIZE_MB}
-                    onTypeError={(err: string) =>
-                      setToast({
-                        hasError: true,
-                        title: 'File upload failed',
-                        message: err
-                      })
-                    }
-                    onSizeError={(err: string) =>
-                      setToast({
-                        hasError: true,
-                        title: 'File upload failed',
-                        message: err
-                      })
-                    }
-                    dropMessageStyle={{
-                      width: '100%',
-                      height: '100%',
-                      position: 'absolute',
-                      background: '#F4F9F9',
-                      top: 0,
-                      right: 2,
-                      display: 'flex',
-                      flexGrow: 2,
-                      opacity: 1,
-                      zIndex: 20,
-                      color: '#008484',
-                      fontSize: 14,
-                      border: 'none'
-                    }}
-                  >
-                    {fileAttachement === null && (
-                      <div className="">
-                        <svg
-                          className="mb-2 inline-block"
-                          width="25"
-                          height="24"
-                          viewBox="0 0 25 24"
-                          fill="none"
-                          xmlns="http://www.w3.org/2000/svg"
-                        >
-                          <path
-                            d="M9.5 17V11L7.5 13"
-                            stroke="#0C1717"
-                            strokeWidth="1.5"
-                            strokeLinecap="round"
-                            strokeLinejoin="round"
-                          />
-                          <path
-                            d="M9.5 11L11.5 13"
-                            stroke="#0C1717"
-                            strokeWidth="1.5"
-                            strokeLinecap="round"
-                            strokeLinejoin="round"
-                          />
-                          <path
-                            d="M22.5 10V15C22.5 20 20.5 22 15.5 22H9.5C4.5 22 2.5 20 2.5 15V9C2.5 4 4.5 2 9.5 2H14.5"
-                            stroke="#0C1717"
-                            strokeWidth="1.5"
-                            strokeLinecap="round"
-                            strokeLinejoin="round"
-                          />
-                          <path
-                            d="M22.5 10H18.5C15.5 10 14.5 9 14.5 6V2L22.5 10Z"
-                            stroke="#0C1717"
-                            strokeWidth="1.5"
-                            strokeLinecap="round"
-                            strokeLinejoin="round"
-                          />
-                        </svg>
-                        <p>
-                          Drag and drop or{' '}
-                          <span className="cursor-pointer text-primary">
-                            choose a file
-                          </span>
-                        </p>
-                      </div>
-                    )}
-                    {fileAttachement !== null && (
-                      <div className="relative h-full w-full px-6 py-5">
-                        <div className="flex h-full w-full items-center justify-items-center gap-2">
-                          <svg
-                            width="40"
-                            height="40"
-                            viewBox="0 0 40 40"
-                            fill="none"
-                            xmlns="http://www.w3.org/2000/svg"
-                          >
-                            <path
-                              d="M35 11.6666V28.3333C35 33.3333 32.5 36.6666 26.6667 36.6666H13.3333C7.5 36.6666 5 33.3333 5 28.3333V11.6666C5 6.66659 7.5 3.33325 13.3333 3.33325H26.6667C32.5 3.33325 35 6.66659 35 11.6666Z"
-                              stroke="#0C1717"
-                              strokeWidth="1.5"
-                              strokeMiterlimit="10"
-                              strokeLinecap="round"
-                              strokeLinejoin="round"
-                            />
-                            <path
-                              d="M24.167 7.5V10.8333C24.167 12.6667 25.667 14.1667 27.5003 14.1667H30.8337"
-                              stroke="#0C1717"
-                              strokeWidth="1.5"
-                              strokeMiterlimit="10"
-                              strokeLinecap="round"
-                              strokeLinejoin="round"
-                            />
-                            <path
-                              d="M13.333 21.6667H19.9997"
-                              stroke="#0C1717"
-                              strokeWidth="1.5"
-                              strokeMiterlimit="10"
-                              strokeLinecap="round"
-                              strokeLinejoin="round"
-                            />
-                            <path
-                              d="M13.333 28.3333H26.6663"
-                              stroke="#0C1717"
-                              strokeWidth="1.5"
-                              strokeMiterlimit="10"
-                              strokeLinecap="round"
-                              strokeLinejoin="round"
-                            />
-                          </svg>
-                          <div className="flex-1 text-left">
-                            <p>{fileAttachement.name}</p>
-                            <p className="text-black-400">
-                              {(fileAttachement.size / (1024 * 1024)).toFixed(
-                                2
-                              )}
-                              MB
-                            </p>
-                          </div>
-                        </div>
-                        <a
-                          onClick={e => {
-                            e.preventDefault();
-                            if (!isSendingFeedback && !isTakingScreenCapture)
-                              setFileAttachement(null);
-                            return false;
-                          }}
-                          className="absolute right-4 top-4 block h-4 w-4 cursor-pointer"
-                          aria-disabled={
-                            isTakingScreenCapture || isSendingFeedback
-                          }
-                        >
-                          <svg
-                            xmlns="http://www.w3.org/2000/svg"
-                            width="16"
-                            height="17"
-                            viewBox="0 0 16 17"
-                            fill="none"
-                          >
-                            <path
-                              d="M4.66602 12.079L11.3327 5.41235"
-                              stroke="#0C1717"
-                              strokeLinecap="round"
-                              strokeLinejoin="round"
-                            />
-                            <path
-                              d="M11.3327 12.079L4.66602 5.41235"
-                              stroke="#0C1717"
-                              strokeLinecap="round"
-                              strokeLinejoin="round"
-                            />
-                          </svg>
-                        </a>
-                      </div>
-                    )}
-                  </FileUploader>
+                  <div className="flex-1 grow">
+                    <Upload
+                      fileOrFiles={fileAttachement}
+                      handleChange={uploadFile}
+                      onClose={() => setFileAttachement(null)}
+                      disabled={
+                        fileAttachement !== null ||
+                        isSendingFeedback ||
+                        isTakingScreenCapture
+                      }
+                      onTypeError={(err: string) =>
+                        setToast({
+                          hasError: true,
+                          title: 'File upload failed',
+                          message: err
+                        })
+                      }
+                      onSizeError={(err: string) =>
+                        setToast({
+                          hasError: true,
+                          title: 'File upload failed',
+                          message: err
+                        })
+                      }
+                    />
+                  </div>
                 </div>
               </div>
               <div className="mt-4 flex justify-between">

--- a/dashboard/components/upload/Upload.stories.tsx
+++ b/dashboard/components/upload/Upload.stories.tsx
@@ -1,0 +1,113 @@
+import type { Meta, StoryObj } from '@storybook/react';
+
+import { useEffect, useState } from 'react';
+import Upload, { UploadProps } from './Upload';
+
+function UploadWrapper({
+  multiple,
+  fileOrFiles,
+  handleChange,
+  onClose,
+  ...otherProps
+}: UploadProps) {
+  const [selectedFile, setSelectedFile] = useState<File | File[] | null>(null);
+
+  useEffect(() => {
+    setSelectedFile(null);
+  }, [multiple]);
+
+  const uploadFile = (file: File | File[] | null): void => {
+    if (file instanceof FileList) {
+      const filesArray = Array.from(file);
+      setSelectedFile(filesArray);
+    } else if (file instanceof File) {
+      setSelectedFile(file);
+    } else {
+      setSelectedFile(null);
+    }
+  };
+
+  return (
+    <Upload
+      multiple={multiple}
+      fileOrFiles={selectedFile}
+      handleChange={uploadFile}
+      onClose={() => setSelectedFile(null)}
+      {...otherProps}
+    />
+  );
+}
+
+const meta: Meta<typeof Upload> = {
+  title: 'Komiser/FileUpload',
+  component: UploadWrapper,
+  decorators: [
+    Story => (
+      <div className="h-full w-full rounded bg-white p-0.5">{Story()}</div>
+    )
+  ],
+  tags: ['autodocs'],
+  argTypes: {
+    name: {
+      control: 'text',
+      description: 'the name for your form (if exist)',
+      defaultValue: 'attachment'
+    },
+    multiple: {
+      control: 'boolean',
+      description:
+        'a boolean to determine whether the multiple files is enabled or not',
+      defaultValue: false
+    },
+    disabled: {
+      control: 'boolean',
+      description: 'disables the input',
+      defaultValue: false
+    },
+    required: {
+      control: 'boolean',
+      description: 'Conditionally set the input field as required',
+      defaultValue: false
+    },
+    hoverTitle: {
+      control: 'text',
+      description: 'text appears(hover) when trying to drop a file',
+      defaultValue: 'drop here'
+    },
+    maxSize: {
+      control: 'number',
+      description: 'the maximum size of the file (number in mb)',
+      defaultValue: 37
+    },
+    minSize: {
+      control: 'number',
+      description: 'the minimum size of the file (number in mb)',
+      defaultValue: 0
+    }
+  }
+};
+
+export default meta;
+
+type Story = StoryObj<typeof Upload>;
+
+export const SingleFile: Story = {
+  args: {
+    name: 'attachment',
+    disabled: false,
+    hoverTitle: 'drop here',
+    maxSize: 37,
+    minSize: 0
+  }
+};
+
+export const MultipleFiles: Story = {
+  args: {
+    name: 'attachment',
+    multiple: true,
+    disabled: false,
+    hoverTitle: 'drop here',
+    maxSize: 37,
+    minSize: 0
+  }
+};

--- a/dashboard/components/upload/Upload.tsx
+++ b/dashboard/components/upload/Upload.tsx
@@ -1,0 +1,324 @@
+import React from 'react';
+import { FileUploader } from 'react-drag-drop-files';
+
+type BaseUploadProps = {
+  name?: string;
+  label?: string;
+  required?: boolean;
+  disabled?: boolean;
+  hoverTitle?: string;
+  classes?: string;
+  childClassName?: string;
+  types?: string[];
+  onTypeError?: (error: string) => void;
+  children?: any;
+  maxSize?: number;
+  minSize?: number;
+  onSizeError?: (error: string) => void;
+  onDrop?: (file: File | null) => void;
+  onSelect?: (file: File | null) => void;
+  onClose: () => void;
+  onDraggingStateChange?: () => void;
+  dropMessageStyle?: React.CSSProperties;
+};
+
+export type SingleUploadProps = BaseUploadProps & {
+  multiple?: false;
+  fileOrFiles: File | null;
+  handleChange: (file: File | null) => void;
+};
+
+export type MultipleUploadProps = BaseUploadProps & {
+  multiple: true;
+  fileOrFiles: File[] | null;
+  handleChange: (files: File[] | null) => void;
+};
+
+export type UploadProps = SingleUploadProps | MultipleUploadProps;
+
+const FILE_TYPES = ['JPG', 'PNG', 'GIF', 'TXT', 'LOG', 'MP4', 'AVI', 'MOV'];
+const MAX_FILE_SIZE_MB = 37;
+
+const defaultDropMessageStyle: React.CSSProperties = {
+  width: '100%',
+  height: '100%',
+  position: 'absolute',
+  background: '#F4F9F9',
+  top: 0,
+  right: 2,
+  display: 'flex',
+  flexGrow: 2,
+  opacity: 1,
+  zIndex: 20,
+  color: '#008484',
+  fontSize: 14,
+  border: 'none'
+};
+
+function Upload({
+  name = 'attachment',
+  multiple,
+  label,
+  required,
+  disabled,
+  hoverTitle = 'drop here',
+  fileOrFiles,
+  handleChange,
+  classes,
+  childClassName,
+  types = FILE_TYPES,
+  onTypeError,
+  maxSize = MAX_FILE_SIZE_MB,
+  minSize,
+  onSizeError,
+  onDrop,
+  onSelect,
+  onClose,
+  onDraggingStateChange,
+  dropMessageStyle = defaultDropMessageStyle
+}: UploadProps) {
+  const defaultChildClassName =
+    fileOrFiles === null
+      ? `grow bg-white cursor-pointer rounded border-2 border-dashed border-black-170 py-5 text-center text-xs transition hover:border-[#B6EAEA] hover:bg-black-100 w-full`
+      : `grow bg-white min-h-full rounded border-2 border-[#B6EAEA] text-center text-xs transition w-full`;
+
+  return (
+    <FileUploader
+      name={name}
+      multiple={multiple}
+      label={label}
+      required={required}
+      disabled={disabled || fileOrFiles !== null}
+      fileOrFiles={fileOrFiles}
+      handleChange={handleChange}
+      classes={classes}
+      types={types}
+      hoverTitle={hoverTitle}
+      onTypeError={onTypeError}
+      maxSize={maxSize}
+      minSize={minSize}
+      onSizeError={onSizeError}
+      onDrop={onDrop}
+      onSelect={onSelect}
+      onDraggingStateChange={onDraggingStateChange}
+      dropMessageStyle={dropMessageStyle}
+    >
+      <div className={childClassName || defaultChildClassName}>
+        {fileOrFiles === null && (
+          <div className="">
+            <svg
+              className="mb-2 inline-block"
+              width="25"
+              height="24"
+              viewBox="0 0 25 24"
+              fill="none"
+              xmlns="http://www.w3.org/2000/svg"
+            >
+              <path
+                d="M9.5 17V11L7.5 13"
+                stroke="#0C1717"
+                strokeWidth="1.5"
+                strokeLinecap="round"
+                strokeLinejoin="round"
+              />
+              <path
+                d="M9.5 11L11.5 13"
+                stroke="#0C1717"
+                strokeWidth="1.5"
+                strokeLinecap="round"
+                strokeLinejoin="round"
+              />
+              <path
+                d="M22.5 10V15C22.5 20 20.5 22 15.5 22H9.5C4.5 22 2.5 20 2.5 15V9C2.5 4 4.5 2 9.5 2H14.5"
+                stroke="#0C1717"
+                strokeWidth="1.5"
+                strokeLinecap="round"
+                strokeLinejoin="round"
+              />
+              <path
+                d="M22.5 10H18.5C15.5 10 14.5 9 14.5 6V2L22.5 10Z"
+                stroke="#0C1717"
+                strokeWidth="1.5"
+                strokeLinecap="round"
+                strokeLinejoin="round"
+              />
+            </svg>
+            <p>
+              Drag and drop or{' '}
+              <span className="cursor-pointer text-primary">choose a file</span>
+            </p>
+          </div>
+        )}
+        {fileOrFiles !== null && (
+          <div className="flex h-full flex-col gap-2">
+            {multiple ? (
+              fileOrFiles?.map((file: File, index: number) => (
+                <div className="relative h-full w-full px-6 py-5" key={index}>
+                  {/* Render the multiple files */}
+                  <div className="flex h-full w-full items-center justify-items-center gap-2">
+                    <svg
+                      width="40"
+                      height="40"
+                      viewBox="0 0 40 40"
+                      fill="none"
+                      xmlns="http://www.w3.org/2000/svg"
+                    >
+                      <path
+                        d="M35 11.6666V28.3333C35 33.3333 32.5 36.6666 26.6667 36.6666H13.3333C7.5 36.6666 5 33.3333 5 28.3333V11.6666C5 6.66659 7.5 3.33325 13.3333 3.33325H26.6667C32.5 3.33325 35 6.66659 35 11.6666Z"
+                        stroke="#0C1717"
+                        strokeWidth="1.5"
+                        strokeMiterlimit="10"
+                        strokeLinecap="round"
+                        strokeLinejoin="round"
+                      />
+                      <path
+                        d="M24.167 7.5V10.8333C24.167 12.6667 25.667 14.1667 27.5003 14.1667H30.8337"
+                        stroke="#0C1717"
+                        strokeWidth="1.5"
+                        strokeMiterlimit="10"
+                        strokeLinecap="round"
+                        strokeLinejoin="round"
+                      />
+                      <path
+                        d="M13.333 21.6667H19.9997"
+                        stroke="#0C1717"
+                        strokeWidth="1.5"
+                        strokeMiterlimit="10"
+                        strokeLinecap="round"
+                        strokeLinejoin="round"
+                      />
+                      <path
+                        d="M13.333 28.3333H26.6663"
+                        stroke="#0C1717"
+                        strokeWidth="1.5"
+                        strokeMiterlimit="10"
+                        strokeLinecap="round"
+                        strokeLinejoin="round"
+                      />
+                    </svg>
+                    <div className="flex-1 text-left">
+                      <p>{file.name}</p>
+                      <p className="text-black-400">
+                        {(file.size / (1024 * 1024)).toFixed(2)}
+                        MB
+                      </p>
+                    </div>
+                  </div>
+                  <a
+                    onClick={onClose}
+                    className={`absolute right-4 top-4 block h-4 w-4 cursor-pointer ${
+                      index !== 0 && 'hidden'
+                    }`}
+                    aria-disabled={!file}
+                  >
+                    <svg
+                      xmlns="http://www.w3.org/2000/svg"
+                      width="16"
+                      height="17"
+                      viewBox="0 0 16 17"
+                      fill="none"
+                    >
+                      <path
+                        d="M4.66602 12.079L11.3327 5.41235"
+                        stroke="#0C1717"
+                        strokeLinecap="round"
+                        strokeLinejoin="round"
+                      />
+                      <path
+                        d="M11.3327 12.079L4.66602 5.41235"
+                        stroke="#0C1717"
+                        strokeLinecap="round"
+                        strokeLinejoin="round"
+                      />
+                    </svg>
+                  </a>
+                </div>
+              ))
+            ) : (
+              <div className="relative h-full w-full px-6 py-5">
+                {/* Render the single file */}
+                <div className="flex h-full w-full items-center justify-items-center gap-2">
+                  <svg
+                    width="40"
+                    height="40"
+                    viewBox="0 0 40 40"
+                    fill="none"
+                    xmlns="http://www.w3.org/2000/svg"
+                  >
+                    <path
+                      d="M35 11.6666V28.3333C35 33.3333 32.5 36.6666 26.6667 36.6666H13.3333C7.5 36.6666 5 33.3333 5 28.3333V11.6666C5 6.66659 7.5 3.33325 13.3333 3.33325H26.6667C32.5 3.33325 35 6.66659 35 11.6666Z"
+                      stroke="#0C1717"
+                      strokeWidth="1.5"
+                      strokeMiterlimit="10"
+                      strokeLinecap="round"
+                      strokeLinejoin="round"
+                    />
+                    <path
+                      d="M24.167 7.5V10.8333C24.167 12.6667 25.667 14.1667 27.5003 14.1667H30.8337"
+                      stroke="#0C1717"
+                      strokeWidth="1.5"
+                      strokeMiterlimit="10"
+                      strokeLinecap="round"
+                      strokeLinejoin="round"
+                    />
+                    <path
+                      d="M13.333 21.6667H19.9997"
+                      stroke="#0C1717"
+                      strokeWidth="1.5"
+                      strokeMiterlimit="10"
+                      strokeLinecap="round"
+                      strokeLinejoin="round"
+                    />
+                    <path
+                      d="M13.333 28.3333H26.6663"
+                      stroke="#0C1717"
+                      strokeWidth="1.5"
+                      strokeMiterlimit="10"
+                      strokeLinecap="round"
+                      strokeLinejoin="round"
+                    />
+                  </svg>
+                  <div className="flex-1 text-left">
+                    <p>{fileOrFiles.name}</p>
+                    <p className="text-black-400">
+                      {(fileOrFiles.size / (1024 * 1024)).toFixed(2)}
+                      MB
+                    </p>
+                  </div>
+                </div>
+                <a
+                  onClick={onClose}
+                  className="absolute right-4 top-4 block h-4 w-4 cursor-pointer"
+                  aria-disabled={fileOrFiles === null}
+                >
+                  <svg
+                    xmlns="http://www.w3.org/2000/svg"
+                    width="16"
+                    height="17"
+                    viewBox="0 0 16 17"
+                    fill="none"
+                  >
+                    <path
+                      d="M4.66602 12.079L11.3327 5.41235"
+                      stroke="#0C1717"
+                      strokeLinecap="round"
+                      strokeLinejoin="round"
+                    />
+                    <path
+                      d="M11.3327 12.079L4.66602 5.41235"
+                      stroke="#0C1717"
+                      strokeLinecap="round"
+                      strokeLinejoin="round"
+                    />
+                  </svg>
+                </a>
+              </div>
+            )}
+          </div>
+        )}
+      </div>
+    </FileUploader>
+  );
+}
+
+export default Upload;


### PR DESCRIPTION
## Problem

The existing Feedback widget in our application had a file upload feature that wasn’t reusable and wasn’t included in our Storybook. 

## Solution

To address this issue, I refactored the file upload feature into its own Upload component. This new component includes all the necessary props and stylings, making it easily reusable across different parts of our application. I also ensured that the FeedbackWidget is now using this new Upload component.

In addition, I added the Upload component to our Storybook. This includes all necessary variants (supporting both single and multiple file uploads) and proper documentation. This will allow developers to easily understand and reuse the Upload component, and ensure consistency in file uploads across our application.

## Changes Made

- Refactored file upload feature into a new, reusable Upload component.
- Updated FeedbackWidget to use the new Upload component.
- Added Upload component to Storybook with support for both single and multiple file uploads.

## Screenshots

<img width="1470" alt="Screenshot 2023-10-19 at 8 41 57 PM" src="https://github.com/tailwarden/komiser/assets/92461238/731c2d60-109b-4650-b7ef-7a01f521a038">

<img width="1470" alt="Screenshot 2023-10-19 at 8 42 22 PM" src="https://github.com/tailwarden/komiser/assets/92461238/fd682f70-dfda-481a-8233-8f8339b82ee6">

## Checklist

- [ x ] Code follows the <a href="https://github.com/tailwarden/komiser/blob/master/CONTRIBUTING.md">contributing</a> guidelines
- [ x ] Changes have been thoroughly tested
- [ x ] <a href="https://github.com/tailwarden/docs.komiser.io">Documentation</a> has been updated, if necessary
- [ x ] Any dependencies have been added to the project, if necessary

## Reviewers

@Traxmaxx 

