### PR TITLE
fix: relation name persisting on screen while hovering graph edges #1066

### DIFF
--- a/dashboard/components/explorer/DependencyGraph.tsx
+++ b/dashboard/components/explorer/DependencyGraph.tsx
@@ -1,7 +1,7 @@
 /* eslint-disable react-hooks/exhaustive-deps */
 import React, { useState, memo, useEffect } from 'react';
 import CytoscapeComponent from 'react-cytoscapejs';
-import Cytoscape, { EventObject } from 'cytoscape';
+import Cytoscape, { EdgeSingular, EventObject } from 'cytoscape';
 import popper from 'cytoscape-popper';
 
 import nodeHtmlLabel, {
@@ -91,6 +91,7 @@ const DependencyGraph = ({ data }: DependencyGraphProps) => {
               const content = document.createElement('div');
               content.classList.add('popper-div');
               content.innerHTML = event.target.data('label');
+              content.style.pointerEvents = 'none';
 
               document.body.appendChild(content);
               return content;
@@ -108,6 +109,20 @@ const DependencyGraph = ({ data }: DependencyGraphProps) => {
 
       // Hide labels when being zoomed out
       cy.on('zoom', event => {
+        if (cy.zoom() <= zoomLevelBreakpoint) {
+          interface ExtendedEdgeSingular extends EdgeSingular {
+            popperRefObj?: any;
+          }
+
+          // Check if a tooltip is present and remove it
+          cy.edges().forEach((edge: ExtendedEdgeSingular) => {
+            if (edge.popperRefObj) {
+              edge.popperRefObj.state.elements.popper.remove();
+              edge.popperRefObj.destroy();
+            }
+          });
+        }
+
         const opacity = cy.zoom() <= zoomLevelBreakpoint ? 0 : 1;
 
         Array.from(
@@ -126,7 +141,7 @@ const DependencyGraph = ({ data }: DependencyGraphProps) => {
 
   return (
     <div className="relative h-full flex-1 bg-dependency-graph bg-[length:40px_40px]">
-      <CytoscapeComponent
+      {/* <CytoscapeComponent
         className="h-full w-full"
         elements={CytoscapeComponent.normalizeElements({
           nodes: data.nodes,
@@ -150,7 +165,7 @@ const DependencyGraph = ({ data }: DependencyGraphProps) => {
           }
         ]}
         cy={(cy: Cytoscape.Core) => cyActionHandlers(cy)}
-      />
+      /> */}
       {dataIsEmpty ? (
         <>
           <div className="translate-y-[201px]">

--- a/dashboard/components/feedback-widget/FeedbackWidget.tsx
+++ b/dashboard/components/feedback-widget/FeedbackWidget.tsx
@@ -52,7 +52,7 @@ const useFeedbackWidget = (defaultState: boolean = false) => {
     const [isTakingScreenCapture, setIsTakingScreenCapture] = useState(false);
     const [fileAttachement, setFileAttachement] = useState<File | null>(null);
     const [isSendingFeedback, setIsSendingFeedback] = useState(false);
-    const { toast, setToast, dismissToast } = useToast();
+    const { toast, showToast, dismissToast } = useToast();
 
     async function takeScreenshot() {
       if (
@@ -83,7 +83,7 @@ const useFeedbackWidget = (defaultState: boolean = false) => {
             setFileAttachement(screenShotFile);
           }
 
-          setToast({
+          showToast({
             hasError: false,
             title: 'Screen capture',
             message:
@@ -91,7 +91,7 @@ const useFeedbackWidget = (defaultState: boolean = false) => {
           });
         })
         .catch(err => {
-          setToast({
+          showToast({
             hasError: true,
             title: 'Screen capture failed',
             message:
@@ -124,7 +124,7 @@ const useFeedbackWidget = (defaultState: boolean = false) => {
           settingsService
             .sendFeedback(formData)
             .then(result => {
-              setToast({
+              showToast({
                 hasError: false,
                 title: 'Feedback sent',
                 message:
@@ -134,7 +134,7 @@ const useFeedbackWidget = (defaultState: boolean = false) => {
               clearFeedbackForm();
             })
             .catch(error => {
-              setToast({
+              showToast({
                 hasError: true,
                 title: 'Feedback',
                 message: 'An Error happened. Maybe try again please!'
@@ -258,14 +258,14 @@ const useFeedbackWidget = (defaultState: boolean = false) => {
                         isTakingScreenCapture
                       }
                       onTypeError={(err: string) =>
-                        setToast({
+                        showToast({
                           hasError: true,
                           title: 'File upload failed',
                           message: err
                         })
                       }
                       onSizeError={(err: string) =>
-                        setToast({
+                        showToast({
                           hasError: true,
                           title: 'File upload failed',
                           message: err

--- a/dashboard/components/feedback-widget/FeedbackWidget.tsx
+++ b/dashboard/components/feedback-widget/FeedbackWidget.tsx
@@ -7,7 +7,7 @@ import Modal from '@components/modal/Modal';
 import Input from '@components/input/Input';
 import settingsService from '@services/settingsService';
 import Button from '@components/button/Button';
-import useToast from '@components/toast/hooks/useToast';
+import { useToast } from '@components/toast/ToastProvider';
 import Toast from '@components/toast/Toast';
 import Upload from '@components/upload/Upload';
 

--- a/dashboard/components/upload/Upload.stories.tsx
+++ b/dashboard/components/upload/Upload.stories.tsx
@@ -10,24 +10,35 @@ function UploadWrapper({
   onClose,
   ...otherProps
 }: UploadProps) {
-  const [selectedFile, setSelectedFile] = useState<File | File[] | null>(null);
+  const [selectedFile, setSelectedFile] = useState<File | null>(null);
+  const [selectedFiles, setSelectedFiles] = useState<File[] | null>(null);
 
   useEffect(() => {
     setSelectedFile(null);
+    setSelectedFiles(null);
   }, [multiple]);
 
   const uploadFile = (file: File | File[] | null): void => {
     if (file instanceof FileList) {
       const filesArray = Array.from(file);
-      setSelectedFile(filesArray);
+      setSelectedFiles(filesArray);
     } else if (file instanceof File) {
       setSelectedFile(file);
     } else {
       setSelectedFile(null);
+      setSelectedFiles(null);
     }
   };
 
-  return (
+  return multiple ? (
+    <Upload
+      multiple={multiple}
+      fileOrFiles={selectedFiles}
+      handleChange={uploadFile}
+      onClose={() => setSelectedFiles(null)}
+      {...otherProps}
+    />
+  ) : (
     <Upload
       multiple={multiple}
       fileOrFiles={selectedFile}
@@ -39,7 +50,7 @@ function UploadWrapper({
 }
 
 const meta: Meta<typeof Upload> = {
-  title: 'Komiser/FileUpload',
+  title: 'Komiser/Upload',
   component: UploadWrapper,
   decorators: [
     Story => (


### PR DESCRIPTION
## Problem

In the current implementation of the Cytoscape graph, we have two issues. First, when users zoom out while hovering over a node relation, the tooltip persists on the screen even after moving the mouse. This behavior can stack and lead to multiple tooltips staying on the screen. Second, when users hover over the tooltip, they are unable to zoom out.

fixes #1066 

## Solution

To solve these issues, I’ve added checks in the zoom event handler to remove any tooltips when zooming crosses its threshold i.e. zoomLevelBreakpoint. I’ve also disabled pointer events on the tooltip to allow zoom events to pass through.

## Changes Made

- Added a check in the zoom event handler to remove tooltips when zooming crosses breakpoint.
- Disabled pointer events on tooltips to allow zoom events to pass through.
- Commented the extra CytoScapeComponent which was overlapping the current Component

## How to Test

1. Zoom on the resources explorer.
2. Hover over a relation between two nodes — the name of the relation appears.
3. Zoom out, keeping the mouse still.
4. The relation caption stays on the screen and disappears as soon as the zooming threshold for the resource names to be hidden is reached.

## Screenshots

<img width="1470" alt="Screenshot 2023-10-22 at 12 59 25 AM" src="https://github.com/tailwarden/komiser/assets/92461238/571eb2d3-7630-401e-8f9f-27c0a620d06e">

<img width="1470" alt="Screenshot 2023-10-22 at 12 59 32 AM" src="https://github.com/tailwarden/komiser/assets/92461238/666dc3aa-2f90-4845-8c6c-18fbe28ab85e">


## Notes

[Any additional notes or information that you would like to share with the reviewers.]

## Checklist

- [x] Code follows the <a href="https://github.com/tailwarden/komiser/blob/master/CONTRIBUTING.md">contributing</a> guidelines
- [x] Changes have been thoroughly tested
- [x] <a href="https://github.com/tailwarden/docs.komiser.io">Documentation</a> has been updated, if necessary
- [x] Any dependencies have been added to the project, if necessary

## Reviewers

@AllieMendes 
