### PR TITLE
fix: useToast import

### DIFF
--- a/dashboard/components/feedback-widget/FeedbackWidget.tsx
+++ b/dashboard/components/feedback-widget/FeedbackWidget.tsx
@@ -7,7 +7,7 @@ import Modal from '@components/modal/Modal';
 import Input from '@components/input/Input';
 import settingsService from '@services/settingsService';
 import Button from '@components/button/Button';
-import useToast from '@components/toast/hooks/useToast';
+import { useToast } from '@components/toast/ToastProvider';
 import Toast from '@components/toast/Toast';
 import Upload from '@components/upload/Upload';
 


### PR DESCRIPTION
It seems we moved the `useToast` from `hooks/useToast` to the `'@components/toast/ToastProvider'` in following PR https://github.com/tailwarden/komiser/pull/1112

This PR resolves the path to fix build fails that happened in #1125 and #1123 
