### PR TITLE
Animate default edges in resources explorer

### DIFF
--- a/dashboard/components/explorer/animateEdge.ts
+++ b/dashboard/components/explorer/animateEdge.ts
@@ -85,13 +85,19 @@ export const animateEdges = async (options: Options, cy: Core) => {
     return options.direction === 'forward' ? v : 1 - v;
   }
 
-  if (typeof window !== 'undefined') {
+  // let animationId: number | null = null;
+
+  if (
+    typeof window !== 'undefined' &&
+    window.document.URL.includes('explorer')
+  ) {
     // Modified but mainly taken from: https://github.com/sgratzl/cytoscape.js-layers/blob/main/samples/animatedEdges.ts
     const cytoLayersModule = await import('cytoscape-layers');
     cyLayers = cytoLayersModule.layers(cy);
     const animationLayer = cyLayers.nodeLayer.insertBefore('canvas');
 
     let start: number | null = null;
+
     let elapsed = 0;
     const update = (time: number) => {
       if (start == null) {
@@ -143,6 +149,13 @@ export const animateEdges = async (options: Options, cy: Core) => {
         checkBoundsPointCount: 5
       }
     );
-    requestAnimationFrame(update);
+    return requestAnimationFrame(update);
   }
+  return {
+    stop: (animationId: number) => {
+      if (animationId !== null) {
+        cancelAnimationFrame(animationId);
+      }
+    }
+  };
 };

--- a/dashboard/components/explorer/animateEdge.ts
+++ b/dashboard/components/explorer/animateEdge.ts
@@ -1,0 +1,147 @@
+import { Core, EdgeSingular, NodeSingular } from 'cytoscape';
+import { IPoint } from 'cytoscape-layers';
+import { edgeAnimationConfig, edgeStyleConfig } from './config';
+
+// maybe this can be needed in the future
+export function dashAnimation(
+  edge: EdgeSingular,
+  duration: number,
+  offset: number
+) {
+  return edge
+    .animation({
+      style: {
+        'line-dash-offset': offset,
+        'line-dash-pattern': edgeAnimationConfig.style['line-dash-pattern']
+      },
+      duration,
+      position: edge.sourceEndpoint(),
+      renderedPosition: edge.sourceEndpoint(),
+      easing: edgeAnimationConfig.easing as 'linear'
+    })
+    .play()
+    .promise('complete');
+}
+
+type Options = {
+  direction: 'alternate' | 'forward' | 'backward';
+  mode: 'speed' | 'duration';
+  modeValue: number;
+  randomOffset: boolean;
+};
+
+function getOrSet<T>(
+  elem: NodeSingular | EdgeSingular,
+  key: string,
+  value: () => T
+): T {
+  const v = elem.scratch(key);
+  if (v != null) {
+    return v;
+  }
+  const vSet = value();
+  elem.scratch(key, vSet);
+  return vSet;
+}
+
+function dist(start: IPoint, end: IPoint) {
+  return Math.sqrt((start.x - end.x) ** 2 + (start.y - end.y) ** 2);
+}
+
+export const animateEdges = async (options: Options, cy: Core) => {
+  let cyLayers;
+
+  function computeFactor(
+    elapsed: number,
+    offset: number,
+    start: IPoint,
+    end: IPoint
+  ) {
+    const distance = dist(start, end);
+    let duration = options.modeValue;
+
+    if (options.mode !== 'duration' && options.modeValue !== 0) {
+      duration = distance / options.modeValue;
+    }
+
+    if (
+      !Number.isFinite(duration) ||
+      Number.isNaN(duration) ||
+      duration === 0
+    ) {
+      return 0;
+    }
+
+    let f = elapsed / duration;
+
+    if (options.direction === 'alternate') {
+      f = f / 2 + offset;
+      const v = 2 * (f - Math.floor(f) - 0.5);
+      return Math.abs(v);
+    }
+
+    f += offset;
+    const v = f - Math.floor(f);
+    return options.direction === 'forward' ? v : 1 - v;
+  }
+
+  if (typeof window !== 'undefined') {
+    const cytoLayersModule = await import('cytoscape-layers');
+    cyLayers = cytoLayersModule.layers(cy);
+    const animationLayer = cyLayers.nodeLayer.insertBefore('canvas');
+
+    let start: number | null = null;
+    let elapsed = 0;
+    const update = (time: number) => {
+      if (start == null) {
+        start = time;
+      }
+      elapsed = time - start;
+      animationLayer.update();
+      requestAnimationFrame(update);
+    };
+    cyLayers.renderPerEdge(
+      animationLayer,
+      (
+        ctx: CanvasRenderingContext2D,
+        edge: EdgeSingular,
+        path: Path2D,
+        startPoint: IPoint,
+        end: IPoint
+      ) => {
+        const offset = options.randomOffset
+          ? getOrSet(edge, '_animOffset', () => Math.random())
+          : 0;
+        const g = ctx.createLinearGradient(
+          startPoint.x,
+          startPoint.y,
+          end.x,
+          end.y
+        );
+
+        const v = computeFactor(elapsed, offset, startPoint, end);
+
+        const colorStop1 = edgeStyleConfig['line-gradient-stop-colors']
+          ? edgeStyleConfig['line-gradient-stop-colors'][0]
+          : '#008484';
+        const colorStop2 = edgeStyleConfig['line-gradient-stop-colors']
+          ? edgeStyleConfig['line-gradient-stop-colors'][1]
+          : '#33CCCC';
+
+        if (typeof colorStop1 === 'string' && typeof colorStop2 === 'string') {
+          g.addColorStop(Math.max(v - 0.1, 0), colorStop1);
+          g.addColorStop(v, 'white');
+          g.addColorStop(Math.min(v + 0.1, 1), colorStop2);
+        }
+        ctx.strokeStyle = g;
+        ctx.lineWidth = 3;
+        ctx.stroke(path);
+      },
+      {
+        checkBounds: true,
+        checkBoundsPointCount: 5
+      }
+    );
+    requestAnimationFrame(update);
+  }
+};

--- a/dashboard/components/explorer/animateEdge.ts
+++ b/dashboard/components/explorer/animateEdge.ts
@@ -86,6 +86,7 @@ export const animateEdges = async (options: Options, cy: Core) => {
   }
 
   if (typeof window !== 'undefined') {
+    // Modified but mainly taken from: https://github.com/sgratzl/cytoscape.js-layers/blob/main/samples/animatedEdges.ts
     const cytoLayersModule = await import('cytoscape-layers');
     cyLayers = cytoLayersModule.layers(cy);
     const animationLayer = cyLayers.nodeLayer.insertBefore('canvas');

--- a/dashboard/components/explorer/config.ts
+++ b/dashboard/components/explorer/config.ts
@@ -94,19 +94,14 @@ export const leafStyleConfig = {
   opacity: 1
 } as Cytoscape.Css.Node;
 
-export const edgeAnimationConfig = [
-  {
-    zoom: { level: 1 },
-    easing: 'linear',
-    style: {
-      'line-dash-offset': 24,
-      'line-dash-pattern': [4, 4]
-    }
+export const edgeAnimationConfig = {
+  easing: 'linear',
+  style: {
+    'line-dash-offset': 24,
+    'line-dash-pattern': [4, 4]
   },
-  {
-    duration: 4000
-  }
-];
+  duration: 4000
+};
 
 export const nodeHTMLLabelConfig = {
   query: 'node', // cytoscape query selector

--- a/dashboard/package-lock.json
+++ b/dashboard/package-lock.json
@@ -16,6 +16,7 @@
         "classnames": "^2.3.2",
         "cytoscape": "^3.26.0",
         "cytoscape-cose-bilkent": "^4.1.0",
+        "cytoscape-layers": "^2.4.2",
         "cytoscape-node-html-label": "^1.2.2",
         "cytoscape-popper": "^2.0.0",
         "html-to-image": "^1.11.11",
@@ -9229,8 +9230,7 @@
     "node_modules/@types/cytoscape": {
       "version": "3.19.11",
       "resolved": "https://registry.npmjs.org/@types/cytoscape/-/cytoscape-3.19.11.tgz",
-      "integrity": "sha512-ny4i4BOoZxdc9DrSa9RrasXHPRFgt0PeINgj/CegzKu7CJO+UQP0KnjebYJ+KoLymyUbCX86vmqz5B3LK10w5Q==",
-      "devOptional": true
+      "integrity": "sha512-ny4i4BOoZxdc9DrSa9RrasXHPRFgt0PeINgj/CegzKu7CJO+UQP0KnjebYJ+KoLymyUbCX86vmqz5B3LK10w5Q=="
     },
     "node_modules/@types/cytoscape-popper": {
       "version": "2.0.2",
@@ -12590,6 +12590,17 @@
       },
       "peerDependencies": {
         "cytoscape": "^3.2.0"
+      }
+    },
+    "node_modules/cytoscape-layers": {
+      "version": "2.4.2",
+      "resolved": "https://registry.npmjs.org/cytoscape-layers/-/cytoscape-layers-2.4.2.tgz",
+      "integrity": "sha512-laJelF434HqG92yIIqSIO7hLII+P9AxSlZJGrc+5LnGI0k2p/JIRi2nhSkjcinWnsInELhXe4WGOHzUgbtCl7w==",
+      "dependencies": {
+        "@types/cytoscape": "^3.19.10"
+      },
+      "peerDependencies": {
+        "cytoscape": "^3.23.0"
       }
     },
     "node_modules/cytoscape-node-html-label": {

--- a/dashboard/package.json
+++ b/dashboard/package.json
@@ -23,6 +23,7 @@
     "classnames": "^2.3.2",
     "cytoscape": "^3.26.0",
     "cytoscape-cose-bilkent": "^4.1.0",
+    "cytoscape-layers": "^2.4.2",
     "cytoscape-node-html-label": "^1.2.2",
     "cytoscape-popper": "^2.0.0",
     "html-to-image": "^1.11.11",


### PR DESCRIPTION
## Problem

#1071 

## Solution

The edges are now animated.

## Changes Made

- Added [Cytoscape Layers](https://github.com/sgratzl/cytoscape.js-layers/tree/main)(Plugin) which allows to add animation to current Cytoscape.
- Clean Up the Typescript script

## How to Test

[Provide instructions on how to test the changes you made, including any relevant details like configuration steps or data to be used for testing.]

## Screenshots

https://github.com/tailwarden/komiser/assets/54506108/e734acd9-1804-45f9-aa0d-627ee893af62

## Notes

- When going from Explorer to Dashboard Home, then there is an error. I think it's a React router thing and it could solve itself when building.

## Checklist

- [X] Code follows the <a href="https://github.com/tailwarden/komiser/blob/master/CONTRIBUTING.md">contributing</a> guidelines
- [X] Changes have been thoroughly tested
- [ ] <a href="https://github.com/tailwarden/docs.komiser.io">Documentation</a> has been updated, if necessary
- [X] Any dependencies have been added to the project, if necessary

## Reviewers

@[username of the reviewer]

