### PR TITLE
update komiser policy to include correct cloudFront function action

### DIFF
--- a/policy.json
+++ b/policy.json
@@ -8,7 +8,7 @@
 				"apigateway:GET",
 				"cloudwatch:GetMetricStatistics",
 				"cloudfront:ListDistributions",
-				"cloudfront:Functions",
+				"cloudfront:ListFunctions",
 				"cloudfront:ListTagsForResource",
 				"cloudwatch:DescribeAlarms",
 				"cloudwatch:ListTagsForResource",


### PR DESCRIPTION
## Problem

An issue was found by a community member (Erik Kristofer Anderson) when recently trying to create a Komiser recommended policy in the AWS IAM policy builder when he came across a syntax error for the a CloudFront service. 

As seen in the screenshot `Cloudfront:Functions` doesn't exist.

## Solution

Add the correct action `"cloudfront:ListFunctions"` to the policy

## Screenshots

![Screenshot 2023-11-07 at 18 38 12](https://github.com/tailwarden/komiser/assets/38757612/8ea36180-8aa4-48aa-a3fe-e294d49cd079)

## Reviewers
@Azanul @AvineshTripathi @ShubhamPalriwala @Kolawole99 

