### PR TITLE
feat: Add Cost Calculation for DigitalOcean Volumes

### DIFF
--- a/providers/digitalocean/storage/volumes.go
+++ b/providers/digitalocean/storage/volumes.go
@@ -13,10 +13,10 @@ import (
 	"github.com/tailwarden/komiser/providers"
 )
 
-var hourlyPrice float64
-const createdLayout = "2006-01-02T15:04:05Z" // 2020-07-21T18:37:44Z
+const createdLayout = "2006-01-02T15:04:05Z"
 
 func Volumes(ctx context.Context, client providers.ProviderClient) ([]models.Resource, error) {
+	var hourlyPrice float64
 	resources := make([]models.Resource, 0)
 	volumes, _, err := client.DigitalOceanClient.Storage.ListVolumes(ctx, &godo.ListVolumeParams{})
 	if err != nil {

--- a/providers/digitalocean/storage/volumes.go
+++ b/providers/digitalocean/storage/volumes.go
@@ -16,7 +16,6 @@ import (
 const createdLayout = "2006-01-02T15:04:05Z"
 
 func Volumes(ctx context.Context, client providers.ProviderClient) ([]models.Resource, error) {
-	var hourlyPrice float64
 	resources := make([]models.Resource, 0)
 	volumes, _, err := client.DigitalOceanClient.Storage.ListVolumes(ctx, &godo.ListVolumeParams{})
 	if err != nil {
@@ -39,7 +38,8 @@ func Volumes(ctx context.Context, client providers.ProviderClient) ([]models.Res
 				})
 			}
 		}
-
+		
+		var hourlyPrice float64
 		sizeInGB := volume.SizeGigaBytes
 		if sizeInGB <= 100 {
 			hourlyPrice = 0.015

--- a/providers/digitalocean/storage/volumes.go
+++ b/providers/digitalocean/storage/volumes.go
@@ -43,8 +43,7 @@ func Volumes(ctx context.Context, client providers.ProviderClient) ([]models.Res
 		sizeInGB := volume.SizeGigaBytes
 		if sizeInGB <= 100 {
 			hourlyPrice = 0.015
-		}
-		if sizeInGB <= 500 && sizeInGB > 100 {
+		} else if sizeInGB <= 500 {
 			hourlyPrice = 0.075
 		} else {
 			hourlyPrice = 0.150


### PR DESCRIPTION
## Problem #1048 

Currently, cost calculation for DigitalOcean volumes is not implemented!
 
## Solution

This PR is fixing tiny issue by adding cost calculation support for volumes of digitalocean


## Changes Made

- Fetching the sizein GB of volume and then calculating the cost based on the fixed price from digitalocean volume [pricing](https://www.digitalocean.com/pricing/volumes)
- fixed the hourly cost as static since its same for all volumes

## Checklist

- [x] Code follows the <a href="https://github.com/tailwarden/komiser/blob/master/CONTRIBUTING.md">contributing</a> guidelines
- [x] Changes have been thoroughly tested
- [x] <a href="https://github.com/tailwarden/docs.komiser.io">Documentation</a> has been updated, if necessary
- [x] Any dependencies have been added to the project, if necessary