### PR TITLE
fix: Civo Database not detected

### DIFF
--- a/providers/civo/civo.go
+++ b/providers/civo/civo.go
@@ -2,10 +2,9 @@ package civo
 
 import (
 	"context"
-	"log"
 
 	"github.com/civo/civogo"
-	"github.com/sirupsen/logrus"
+	log "github.com/sirupsen/logrus"
 	"github.com/tailwarden/komiser/providers"
 	"github.com/tailwarden/komiser/providers/civo/compute"
 	"github.com/tailwarden/komiser/providers/civo/kubernetes"
@@ -51,7 +50,7 @@ func FetchResources(ctx context.Context, client providers.ProviderClient, db *bu
 				for _, resource := range resources {
 					_, err := db.NewInsert().Model(&resource).On("CONFLICT (resource_id) DO UPDATE").Set("cost = EXCLUDED.cost, relations=EXCLUDED.relations").Exec(context.Background())
 					if err != nil {
-						logrus.WithError(err).Errorf("db trigger failed")
+						log.WithError(err).Errorf("db trigger failed")
 					}
 				}
 				if telemetry {


### PR DESCRIPTION
## Problem

Civo Databases were not being detected

## Solution

The size was not being sent in GB but as the instance name. Wrote & used a utility function to map all available instance types to their respective sizes in GB.


## Screenshots

![Screenshot 2023-11-14 at 12 10 10 AM](https://github.com/tailwarden/komiser/assets/42029519/090149ae-64dd-48b0-85a1-db9ab98df239)

## Checklist

- [X] Code follows the <a href="https://github.com/tailwarden/komiser/blob/master/CONTRIBUTING.md">contributing</a> guidelines
- [X] Changes have been thoroughly tested
- [X] <a href="https://github.com/tailwarden/docs.komiser.io">Documentation</a> has been updated, if necessary
- [X] Any dependencies have been added to the project, if necessary

## Reviewers

@jakepage91 @mlabouardy @AvineshTripathi 

