### PR TITLE
fix(1206): Resource fetching performance improvement for MongoDb

### DIFF
--- a/internal/internal.go
+++ b/internal/internal.go
@@ -252,7 +252,7 @@ func triggerFetchingWorfklow(ctx context.Context, client providers.ProviderClien
 	case "Scaleway":
 		scaleway.FetchResources(ctx, client, db, telemetry, analytics)
 	case "MongoDBAtlas":
-		mongodbatlas.FetchResources(ctx, client, db, telemetry, analytics)
+		mongodbatlas.FetchResources(ctx, client, db, telemetry, analytics, wp)
 	case "GCP":
 		gcp.FetchResources(ctx, client, db, telemetry, analytics, wp)
 	case "OVH":

--- a/providers/mongodbatlas/mongodbatlas.go
+++ b/providers/mongodbatlas/mongodbatlas.go
@@ -17,25 +17,45 @@ func listOfSupportedServices() []providers.FetchDataFunction {
 	}
 }
 
-func FetchResources(ctx context.Context, client providers.ProviderClient, db *bun.DB, telemetry bool, analytics utils.Analytics) {
+func FetchResources(ctx context.Context, client providers.ProviderClient, db *bun.DB, telemetry bool, analytics utils.Analytics, wp *providers.WorkerPool) {
 	for _, fetchResources := range listOfSupportedServices() {
-		resources, err := fetchResources(ctx, client)
-		if err != nil {
-			log.Printf("[%s][MongoDBAtlas] %s", client.Name, err)
-		} else {
-			for _, resource := range resources {
-				_, err := db.NewInsert().Model(&resource).On("CONFLICT (resource_id) DO UPDATE").Set("cost = EXCLUDED.cost").Exec(context.Background())
-				if err != nil {
-					logrus.WithError(err).Errorf("db trigger failed")
-				}
+		// resources, err := fetchResources(ctx, client)
+		// if err != nil {
+		// 	log.Printf("[%s][MongoDBAtlas] %s", client.Name, err)
+		// } else {
+		// 	for _, resource := range resources {
+		// 		_, err := db.NewInsert().Model(&resource).On("CONFLICT (resource_id) DO UPDATE").Set("cost = EXCLUDED.cost").Exec(context.Background())
+		// 		if err != nil {
+		// 			logrus.WithError(err).Errorf("db trigger failed")
+		// 		}
 
+		// 	}
+		// 	if telemetry {
+		// 		analytics.TrackEvent("discovered_resources", map[string]interface{}{
+		// 			"provider":  "MongoDBAtlas",
+		// 			"resources": len(resources),
+		// 		})
+		// 	}
+		// }
+		wp.SubmitTask(func() {
+			resources, err := fetchResources(ctx, client)
+			if err != nil {
+				log.Printf("[%s][MongoDBAtlas] %s", client.Name, err)
+			} else {
+				for _, resource := range resources {
+					_, err := db.NewInsert().Model(&resource).On("CONFLICT (resource_id) DO UPDATE").Set("cost = EXCLUDED.cost").Exec(context.Background())
+					if err != nil {
+						logrus.WithError(err).Errorf("db trigger failed")
+					}
+				}
+				if telemetry {
+					analytics.TrackEvent("discovered_resources", map[string]interface{}{
+						"provider":  "MongoDBAtlas",
+						"resources": len(resources),
+					})
+				}
 			}
-			if telemetry {
-				analytics.TrackEvent("discovered_resources", map[string]interface{}{
-					"provider":  "MongoDBAtlas",
-					"resources": len(resources),
-				})
-			}
-		}
+		})
+
 	}
 }

--- a/providers/mongodbatlas/mongodbatlas.go
+++ b/providers/mongodbatlas/mongodbatlas.go
@@ -19,24 +19,6 @@ func listOfSupportedServices() []providers.FetchDataFunction {
 
 func FetchResources(ctx context.Context, client providers.ProviderClient, db *bun.DB, telemetry bool, analytics utils.Analytics, wp *providers.WorkerPool) {
 	for _, fetchResources := range listOfSupportedServices() {
-		// resources, err := fetchResources(ctx, client)
-		// if err != nil {
-		// 	log.Printf("[%s][MongoDBAtlas] %s", client.Name, err)
-		// } else {
-		// 	for _, resource := range resources {
-		// 		_, err := db.NewInsert().Model(&resource).On("CONFLICT (resource_id) DO UPDATE").Set("cost = EXCLUDED.cost").Exec(context.Background())
-		// 		if err != nil {
-		// 			logrus.WithError(err).Errorf("db trigger failed")
-		// 		}
-
-		// 	}
-		// 	if telemetry {
-		// 		analytics.TrackEvent("discovered_resources", map[string]interface{}{
-		// 			"provider":  "MongoDBAtlas",
-		// 			"resources": len(resources),
-		// 		})
-		// 	}
-		// }
 		wp.SubmitTask(func() {
 			resources, err := fetchResources(ctx, client)
 			if err != nil {


### PR DESCRIPTION
## Problem

Synchronous fetching of resources for MongoDB

## Solution

Submitting the tasks to worker pool instead of executing synchronously.

## Changes Made 
-Update respective function signature
-Use `providers.WorkerPool.SubmitTask` to submit the task to worker pool


## Checklist

- [x] Code follows the <a href="https://github.com/tailwarden/komiser/blob/master/CONTRIBUTING.md">contributing</a> guidelines

