### PR TITLE
Check for nil VpcId and SubnetId before use

### DIFF
--- a/providers/aws/ec2/instances.go
+++ b/providers/aws/ec2/instances.go
@@ -174,9 +174,9 @@ func Instances(ctx context.Context, client providers.ProviderClient) ([]models.R
 }
 
 func getEC2Relations(inst *etype.Instance, resourceArn string) []models.Link {
-	
+
 	var rel []models.Link
-	// Get associated security groups	
+	// Get associated security groups
 	for _, sgrp := range inst.SecurityGroups {
 		rel = append(rel, models.Link{
 			ResourceID: *sgrp.GroupId,
@@ -197,21 +197,25 @@ func getEC2Relations(inst *etype.Instance, resourceArn string) []models.Link {
 		})
 	}
 
-	// Get associated VPC
-	rel = append(rel, models.Link{
-		ResourceID: fmt.Sprintf("%s:vpc/%s", resourceArn, *inst.VpcId),
-		Type:       "VPC",
-		Name:       *inst.VpcId,
-		Relation:   "USES",
-	})
+	if inst.VpcId != nil {
+		// Get associated VPC
+		rel = append(rel, models.Link{
+			ResourceID: fmt.Sprintf("%s:vpc/%s", resourceArn, *inst.VpcId),
+			Type:       "VPC",
+			Name:       *inst.VpcId,
+			Relation:   "USES",
+		})
+	}
 
-	// Get associated Subnet
-	rel = append(rel, models.Link{
-		ResourceID: fmt.Sprintf("%s:subnet/%s", resourceArn, *inst.SubnetId),
-		Name:       *inst.SubnetId,
-		Type:       "Subnet",
-		Relation:   "USES",
-	})
+	if inst.SubnetId != nil {
+		// Get associated Subnet
+		rel = append(rel, models.Link{
+			ResourceID: fmt.Sprintf("%s:subnet/%s", resourceArn, *inst.SubnetId),
+			Name:       *inst.SubnetId,
+			Type:       "Subnet",
+			Relation:   "USES",
+		})
+	}
 
 	// Get associated Keypair
 	if inst.KeyName != nil {


### PR DESCRIPTION
Fixes #1250

## Problem

A couple of nil pointer dereference errors appeared for me while enumerating resources across multiple AWS accounts.

## Solution

Include a simple check that `inst.VpcId` and `inst.SubnetId` are not nil prior to adding them as a link.

## Changes Made

- check that `inst.VpcId` is not nil prior to using it in a `models.Link`
- check that `inst.SubnetId` is not nil prior to using it in a `models.Link`

## How to Test

This error appeared very shortly after running `komiser start`. As described in #1250, I have two AWS accounts configured. This may or may not be an important piece of information for this bug.

## Notes

I do not know why the EC2 instance resource came back with nil values for VPC ID and Subnet ID. This behavior only occurred _after_ I had deleted a few EC2 instances from one AWS account. However, when I removed the cloud account from the config, the error continued to display every time I ran `komiser start`. That suggests to me that the offending EC2 instance belongs in the other AWS account, where I did not delete any EC2 instances. This could very well just be a red herring, but I figured I'd mention it.

## Checklist

- [X] Code follows the <a href="https://github.com/tailwarden/komiser/blob/master/CONTRIBUTING.md">contributing</a> guidelines
- [X] Changes have been thoroughly tested
- [X] <a href="https://github.com/tailwarden/docs.komiser.io">Documentation</a> has been updated, if necessary
- [X] Any dependencies have been added to the project, if necessary

## Reviewers



