### PR TITLE
Escape Curly Brackets

### DIFF
--- a/docs/configuration/cloud-providers/aws.mdx
+++ b/docs/configuration/cloud-providers/aws.mdx
@@ -271,7 +271,7 @@ We will be using the official Komiser [Helm Chart](https://github.com/tailwarden
    echo "${TRUST_RELATIONSHIP}" > trust.json
    ```
 
-<Info> Make sure to substitute ${NAMESPACE} for the namespace you will deploy the helm chart in. If deployed in any other namespace, you will see sts:AssumeRoleWithWebIdentity failure messages in the pod logs. </Info>
+<Info> Make sure to substitute `${NAMESPACE}` for the namespace you will deploy the helm chart in. If deployed in any other namespace, you will see sts:AssumeRoleWithWebIdentity failure messages in the pod logs. </Info>
 
 1. Run the modified code block from the previous step to create a file named *`trust.json`*\.
 


### PR DESCRIPTION
## Problem

Curly brackets are currently not directly supported. They can either be supported with backticks or `\`

## Solution

Added backticks 

## Changes Made

- [List the changes you made in this pull request, including any new features or bug fixes.]

## How to Test

Run `mintlify dev` and navigate to http:localhost:3000/configuration/cloud-providers/aws)

## Screenshots

<img width="722" alt="CleanShot 2023-12-14 at 11 44 20@2x" src="https://github.com/tailwarden/komiser/assets/123998500/7c15e127-d4cb-4dcc-8e99-d00bca0c79b5">
## Notes

## Checklist

- [ ] Code follows the <a href="https://github.com/tailwarden/komiser/blob/master/CONTRIBUTING.md">contributing</a> guidelines
- [ ] Changes have been thoroughly tested
- [ ] <a href="https://github.com/tailwarden/docs.komiser.io">Documentation</a> has been updated, if necessary
- [ ] Any dependencies have been added to the project, if necessary


