### PR TITLE
feat: 6 month cost data history

### DIFF
--- a/handlers/dashboard_handler.go
+++ b/handlers/dashboard_handler.go
@@ -197,7 +197,7 @@ func (handler *ApiHandler) CostBreakdownHandler(c *gin.Context) {
 			return
 		}
 	} else {
-		err = handler.db.NewRaw(fmt.Sprintf(`%s DATE(fetched_at) BETWEEN '%s' AND '%s' GROUP BY %s;`, query, input.Start, input.End, input.Group)).Scan(handler.ctx, &groups)
+		err = handler.db.NewRaw(fmt.Sprintf(`%s DATE(fetched_at) BETWEEN '%s' AND '%s' GROUP BY period, %s;`, query, input.Start, input.End, input.Group)).Scan(handler.ctx, &groups)
 		if err != nil {
 			c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
 			return

--- a/providers/aws/aws.go
+++ b/providers/aws/aws.go
@@ -3,6 +3,7 @@ package aws
 import (
 	"context"
 	"encoding/json"
+	"strconv"
 	"strings"
 	"time"
 
@@ -132,6 +133,18 @@ func FetchResources(ctx context.Context, client providers.ProviderClient, region
 		}
 		if err := writeCostExplorerCache(costexplorerOutputList); err != nil {
 			log.Warn("Failed to write cost explorer cache:", err)
+		}
+		resources, err := awsUtils.ExtractResources(costexplorerOutputList)
+		if err != nil {
+			log.Warn("Failed to extract resources from cost explorer output:", err)
+		}
+		for i, resource := range resources {
+			resource.ResourceId = "OLD_RESOURCE_" + strconv.Itoa(i)
+			resource.Account = client.Name
+			_, err = db.NewInsert().Model(&resource).On("CONFLICT (resource_id) DO UPDATE").Set("cost = EXCLUDED.cost, relations=EXCLUDED.relations").Exec(context.Background())
+			if err != nil {
+				log.WithError(err).Errorf("db trigger failed")
+			}
 		}
 	}
 


### PR DESCRIPTION
## Problem

Komiser only records cost data from the instant it's started, ignoring past data

## Solution

Use AWS cost explorer API to fetch and store 6 months cost history

## Screenshots

[Include screenshots, if relevant, to help reviewers understand the changes you made.]

## Notes

[Any additional notes or information that you would like to share with the reviewers.]

## Checklist

- [ ] Code follows the <a href="https://github.com/tailwarden/komiser/blob/master/CONTRIBUTING.md">contributing</a> guidelines
- [ ] Changes have been thoroughly tested
- [ ] <a href="https://github.com/tailwarden/docs.komiser.io">Documentation</a> has been updated, if necessary
- [ ] Any dependencies have been added to the project, if necessary

