### PR TITLE
fix: fetching for wizard getting scheduled, not running immedeately

### DIFF
--- a/handlers/accounts_handler.go
+++ b/handlers/accounts_handler.go
@@ -125,6 +125,7 @@ func (handler *ApiHandler) NewCloudAccountHandler(c *gin.Context) {
 			c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
 			return
 		}
+		cron.StartAsync()
 	}
 
 	if handler.telemetry {


### PR DESCRIPTION
## Problem

Fetching resources workflow getting scheduled but not running immedeately

## Solution

calling `cron.StartAsync` to start the job(s) without blocking current thread

## Checklist

- [X] Code follows the <a href="https://github.com/tailwarden/komiser/blob/master/CONTRIBUTING.md">contributing</a> guidelines
- [X] Changes have been thoroughly tested
- [X] <a href="https://github.com/tailwarden/docs.komiser.io">Documentation</a> has been updated, if necessary
- [X] Any dependencies have been added to the project, if necessary

