### PR TITLE
feat: added button to onboard new accounts

### DIFF
--- a/dashboard/components/cloud-account/components/CloudAccountsLayout.tsx
+++ b/dashboard/components/cloud-account/components/CloudAccountsLayout.tsx
@@ -2,6 +2,7 @@ import { NextRouter } from 'next/router';
 import { ReactNode, useContext } from 'react';
 
 import platform, { allProviders } from '@utils/providerHelper';
+import Button from '@components/button/Button';
 import GlobalAppContext from '../../layout/context/GlobalAppContext';
 import { CloudAccount } from '../hooks/useCloudAccounts/useCloudAccount';
 
@@ -81,6 +82,15 @@ function CloudAccountsLayout({
               })}
           </div>
         )}
+        <div className="flex flex-col justify-end absolute bottom-10 border-t border-gray-300 p-4">
+          <Button
+            onClick={() => {
+              router.push('/onboarding/choose-cloud/');
+            }}
+          >
+            Add An Account
+          </Button>
+        </div>
       </nav>
       <main className="ml-[17rem]">{children}</main>
     </>


### PR DESCRIPTION
added button on `cloud-accounts` page to onboard new accounts. Currently one can add accounts only if there are no accounts in the `cloud-account` list
![2024-02-12_00-41](https://github.com/tailwarden/komiser/assets/73980067/05a37db3-b080-419c-98dd-1a684144925e)
