### PR TITLE
fix: db nil error during initiation

### DIFF
--- a/internal/internal.go
+++ b/internal/internal.go
@@ -41,7 +41,7 @@ func Exec(address string, port int, configPath string, telemetry bool, a utils.A
 		return err
 	}
 
-	err = utils.SetupDBConnection(cfg, db)
+	db, err = utils.SetupDBConnection(cfg)
 	if err != nil {
 		return err
 	}

--- a/internal/resources_test.go
+++ b/internal/resources_test.go
@@ -21,7 +21,7 @@ func BenchmarkFetchResources(b *testing.B) {
 	if err != nil {
 		b.Fatalf("Error during config setup: %v", err)
 	}
-	err = utils.SetupDBConnection(cfg, db)
+	db, err = utils.SetupDBConnection(cfg)
 	if err != nil {
 		b.Fatalf("Error during DB setup: %v", err)
 	}


### PR DESCRIPTION
db db variable in the `internal.go` file was not populated by the `utils.SetupDBConnection` function and becuase of that the `db.Dialect().Name()` func returned a error in the NewApiHandler func stopping the server to start.